### PR TITLE
fix: Remove hostport for pods

### DIFF
--- a/controllers/internal/fullnode/pod_builder.go
+++ b/controllers/internal/fullnode/pod_builder.go
@@ -99,43 +99,36 @@ var fullNodePorts = []corev1.ContainerPort{
 	{
 		Name:          "api",
 		Protocol:      corev1.ProtocolTCP,
-		HostPort:      1317,
 		ContainerPort: 1317,
 	},
 	{
 		Name:          "rosetta",
 		Protocol:      corev1.ProtocolTCP,
-		HostPort:      8080,
 		ContainerPort: 8080,
 	},
 	{
 		Name:          "grpc",
 		Protocol:      corev1.ProtocolTCP,
-		HostPort:      9090,
 		ContainerPort: 9090,
 	},
 	{
 		Name:          "prometheus",
 		Protocol:      corev1.ProtocolTCP,
-		HostPort:      26660,
 		ContainerPort: 26660,
 	},
 	{
 		Name:          "p2p",
 		Protocol:      corev1.ProtocolTCP,
-		HostPort:      26656,
 		ContainerPort: 26656,
 	},
 	{
 		Name:          "rpc",
 		Protocol:      corev1.ProtocolTCP,
-		HostPort:      26657,
 		ContainerPort: 26657,
 	},
 	{
 		Name:          "web",
 		Protocol:      corev1.ProtocolTCP,
-		HostPort:      9091,
 		ContainerPort: 9091,
 	},
 }

--- a/controllers/internal/fullnode/pod_builder_test.go
+++ b/controllers/internal/fullnode/pod_builder_test.go
@@ -86,7 +86,7 @@ func TestPodBuilder(t *testing.T) {
 			require.Equal(t, tt.Name, port.Name, tt)
 			require.Equal(t, corev1.ProtocolTCP, port.Protocol)
 			require.Equal(t, tt.Port, port.ContainerPort)
-			require.Equal(t, tt.Port, port.HostPort)
+			require.Zero(t, port.HostPort)
 		}
 	})
 


### PR DESCRIPTION
Using `HostPort` limits our pods to a single host (i.e. node in a node pool). 

With this operator, I am removing that constraint. Forcing k8s admins to use a pod per node is not typical for kubernetes and my guess is will be an unpleasant surprise to most k8s admins.

Additionally, k8s recommends using hostports as a last resort:

https://kubernetes.io/docs/concepts/configuration/overview/#services

> Don't specify a hostPort for a Pod unless it is absolutely necessary. When you bind a Pod to a hostPort, it limits the number of places the Pod can be scheduled, because each <hostIP, hostPort, protocol> combination must be unique.

> If you explicitly need to expose a Pod's port on the node, consider using a NodePort Service before resorting to hostPort.

The idiomatic move, imo, is to use a Service as k8s docs suggest above. This may have implications with how we do monitoring currently but I think we can evolve our monitoring to work with a more idiomatic k8s configuration.

For PVCs, we can trust the scheduler. My recent experience with GKE and EKS, the scheduler does not schedule pods in a zone different from its volume mounts. Azure works almost as well, but I did run into issues where it would cause downtime for a node upgrade. 

For initial release, I think we advertise GKE is supported, others YMMV.

There may be a future wheer we expose affinity or other features to give the admin more control over scheduling.