### PR TITLE
refactor: Custom chain label as selector

### DIFF
--- a/controllers/internal/fullnode/labels.go
+++ b/controllers/internal/fullnode/labels.go
@@ -2,17 +2,16 @@ package fullnode
 
 import (
 	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
+	"github.com/strangelove-ventures/cosmos-operator/controllers/internal/kube"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	chainLabel = "cosmosfullnode.cosmos.strange.love/chain-name"
-
 	// Denotes the resource's revision typically using hex-encoded fnv hash. Used to detect resource changes for updates.
 	revisionLabel = "cosmosfullnode.cosmos.strange.love/resource-revision"
 )
 
 // SelectorLabels returns the labels used in selector operations.
 func SelectorLabels(crd *cosmosv1.CosmosFullNode) client.MatchingLabels {
-	return map[string]string{chainLabel: crd.Name}
+	return map[string]string{kube.NameLabel: appName(crd)}
 }

--- a/controllers/internal/fullnode/labels_test.go
+++ b/controllers/internal/fullnode/labels_test.go
@@ -15,5 +15,5 @@ func TestSelectorLabels(t *testing.T) {
 	crd.Name = "cool-chain"
 
 	got := SelectorLabels(crd)
-	require.Equal(t, client.MatchingLabels{"cosmosfullnode.cosmos.strange.love/chain-name": "cool-chain"}, got)
+	require.Equal(t, client.MatchingLabels{"app.kubernetes.io/name": "cool-chain-fullnode"}, got)
 }

--- a/controllers/internal/fullnode/pod_builder.go
+++ b/controllers/internal/fullnode/pod_builder.go
@@ -41,9 +41,8 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: crd.Namespace,
 			Labels: map[string]string{
-				chainLabel:           kube.ToLabelValue(crd.Name),
 				kube.ControllerLabel: kube.ToLabelValue("CosmosFullNode"),
-				kube.NameLabel:       kube.ToLabelValue(fmt.Sprintf("%s-fullnode", crd.Name)),
+				kube.NameLabel:       appName(crd),
 				kube.VersionLabel:    kube.ParseImageVersion(tpl.Image),
 				revisionLabel:        podRevisionHash(crd),
 			},
@@ -153,6 +152,10 @@ func (b PodBuilder) WithOrdinal(ordinal int32) PodBuilder {
 
 	b.pod = pod
 	return b
+}
+
+func appName(crd *cosmosv1.CosmosFullNode) string {
+	return kube.ToLabelValue(fmt.Sprintf("%s-fullnode", crd.Name))
 }
 
 func podName(crdName string, ordinal int32) string {

--- a/controllers/internal/fullnode/pod_builder_test.go
+++ b/controllers/internal/fullnode/pod_builder_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
+	"github.com/strangelove-ventures/cosmos-operator/controllers/internal/kube"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -61,11 +62,10 @@ func TestPodBuilder(t *testing.T) {
 		// The fuzz test below tests this property.
 		delete(pod.Labels, revisionLabel)
 		wantLabels := map[string]string{
-			"cosmosfullnode.cosmos.strange.love/chain-name": "osmosis",
-			"app.kubernetes.io/instance":                    "osmosis-fullnode-5",
-			"app.kubernetes.io/created-by":                  "cosmosfullnode",
-			"app.kubernetes.io/name":                        "osmosis-fullnode",
-			"app.kubernetes.io/version":                     "v1.2.3",
+			"app.kubernetes.io/instance":   "osmosis-fullnode-5",
+			"app.kubernetes.io/created-by": "cosmosfullnode",
+			"app.kubernetes.io/name":       "osmosis-fullnode",
+			"app.kubernetes.io/version":    "v1.2.3",
 		}
 		require.Equal(t, wantLabels, pod.Labels)
 
@@ -86,17 +86,17 @@ func TestPodBuilder(t *testing.T) {
 		require.Equal(t, crd.Spec.PodTemplate.Resources, lastContainer.Resources)
 		require.NotEmpty(t, lastContainer.VolumeMounts) // TODO (nix - 8/12/22) Better assertion once we know what container needs.
 
+		vols := pod.Spec.Volumes
+		require.Len(t, vols, 1)
+		require.Equal(t, "vol-osmosis-fullnode-5", vols[0].Name)
+		require.Equal(t, "pvc-osmosis-fullnode-5", vols[0].PersistentVolumeClaim.ClaimName)
+
 		// Test we don't share or leak data per invocation.
 		pod = builder.Build()
 		require.Empty(t, pod.Name)
 
 		pod = builder.WithOrdinal(123).Build()
 		require.Equal(t, "osmosis-fullnode-123", pod.Name)
-
-		vols := pod.Spec.Volumes
-		require.Len(t, vols, 1)
-		require.Equal(t, "vol-osmosis-fullnode-123", vols[0].Name)
-		require.Equal(t, "pvc-osmosis-fullnode-123", vols[0].PersistentVolumeClaim.ClaimName)
 	})
 
 	t.Run("happy path - ports", func(t *testing.T) {
@@ -128,7 +128,7 @@ func TestPodBuilder(t *testing.T) {
 	t.Run("happy path - optional fields", func(t *testing.T) {
 		optCrd := crd.DeepCopy()
 
-		optCrd.Spec.PodTemplate.Metadata.Labels = map[string]string{"custom": "label", chainLabel: "should not see me"}
+		optCrd.Spec.PodTemplate.Metadata.Labels = map[string]string{"custom": "label", kube.NameLabel: "should not see me"}
 		optCrd.Spec.PodTemplate.Metadata.Annotations = map[string]string{"custom": "annotation", OrdinalAnnotation: "should not see me"}
 
 		optCrd.Spec.PodTemplate.Affinity = &corev1.Affinity{
@@ -149,7 +149,7 @@ func TestPodBuilder(t *testing.T) {
 
 		require.Equal(t, "label", pod.Labels["custom"])
 		// Operator label takes precedence.
-		require.Equal(t, "osmosis", pod.Labels[chainLabel])
+		require.Equal(t, "osmosis-fullnode", pod.Labels[kube.NameLabel])
 
 		require.Equal(t, "annotation", pod.Annotations["custom"])
 		// Operator label takes precedence.

--- a/controllers/internal/fullnode/pod_control_test.go
+++ b/controllers/internal/fullnode/pod_control_test.go
@@ -70,7 +70,7 @@ func TestPodControl_Reconcile(t *testing.T) {
 		}
 		require.Equal(t, namespace, listOpt.Namespace)
 		require.Zero(t, listOpt.Limit)
-		require.Equal(t, "cosmosfullnode.cosmos.strange.love/chain-name=hub", listOpt.LabelSelector.String())
+		require.Equal(t, "app.kubernetes.io/name=hub-fullnode", listOpt.LabelSelector.String())
 		require.Equal(t, ".metadata.controller=hub", listOpt.FieldSelector.String())
 	})
 

--- a/controllers/internal/fullnode/pvc_builder.go
+++ b/controllers/internal/fullnode/pvc_builder.go
@@ -28,7 +28,6 @@ func BuildPVCs(crd *cosmosv1.CosmosFullNode) []*corev1.PersistentVolumeClaim {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: crd.Namespace,
 			Labels: map[string]string{
-				chainLabel:           kube.ToLabelValue(crd.Name),
 				kube.ControllerLabel: kube.ToLabelValue("CosmosFullNode"),
 				kube.NameLabel:       kube.ToLabelValue(fmt.Sprintf("%s-fullnode", crd.Name)),
 				revisionLabel:        pvcRevisionHash(crd),

--- a/controllers/internal/fullnode/pvc_builder_test.go
+++ b/controllers/internal/fullnode/pvc_builder_test.go
@@ -45,9 +45,8 @@ func TestBuildPVCs(t *testing.T) {
 			require.Equal(t, "v1", got.APIVersion)
 
 			wantLabels := map[string]string{
-				"cosmosfullnode.cosmos.strange.love/chain-name": "juno",
-				"app.kubernetes.io/created-by":                  "cosmosfullnode",
-				"app.kubernetes.io/name":                        "juno-fullnode",
+				"app.kubernetes.io/created-by": "cosmosfullnode",
+				"app.kubernetes.io/name":       "juno-fullnode",
 			}
 			// These labels change and tested elsewhere.
 			delete(got.Labels, revisionLabel)

--- a/controllers/internal/fullnode/pvc_control_test.go
+++ b/controllers/internal/fullnode/pvc_control_test.go
@@ -64,7 +64,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		}
 		require.Equal(t, namespace, listOpt.Namespace)
 		require.Zero(t, listOpt.Limit)
-		require.Equal(t, "cosmosfullnode.cosmos.strange.love/chain-name=hub", listOpt.LabelSelector.String())
+		require.Equal(t, "app.kubernetes.io/name=hub-fullnode", listOpt.LabelSelector.String())
 		require.Equal(t, ".metadata.controller=hub", listOpt.FieldSelector.String())
 	})
 


### PR DESCRIPTION
Less is more.

We can use the [kube recommended](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) label of `app.kubernetes.io/name` as the selector. 