### PR TITLE
fix: Make seeds and peers optional

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -286,12 +286,14 @@ type CosmosTendermintConfig struct {
 	// See https://docs.tendermint.com/master/spec/p2p/peer.html and
 	// https://docs.tendermint.com/master/spec/p3p/config.html#persistent-peers.
 	// +kubebuilder:validation:MinLength:=1
+	// +optional
 	PersistentPeers string `json:"peers"`
 
 	// Comma delimited list of p2p seed nodes in <ID>@<IP>:<PORT> format.
 	// See https://docs.tendermint.com/master/spec/p2p/config.html#seeds and
 	// https://docs.tendermint.com/master/spec/p2p/node.html#seeds.
 	// +kubebuilder:validation:MinLength:=1
+	// +optional
 	Seeds string `json:"seeds"`
 
 	// p2p maximum number of inbound peers.

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -162,9 +162,6 @@ spec:
                           and https://docs.tendermint.com/master/spec/p2p/node.html#seeds.
                         minLength: 1
                         type: string
-                    required:
-                    - peers
-                    - seeds
                     type: object
                   genesisScript:
                     description: 'Specify shell (sh) script commands to properly download


### PR DESCRIPTION
In our own infra we sometimes set both, or one or the other. Tendermint allows for other peer types like "private". Therefore, I don't think we can make these required even though they will be used most of the time. 