### PR TITLE
feat: Record events

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,10 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
-	if err = controllers.NewFullNode(mgr.GetClient()).SetupWithManager(ctx, mgr); err != nil {
+	if err = controllers.NewFullNode(
+		mgr.GetClient(),
+		mgr.GetEventRecorderFor("CosmosFullNode"),
+	).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CosmosFullNode")
 		os.Exit(1)
 	}


### PR DESCRIPTION
K8S events show up when you `kubectl describe <kind> <object>`. 

It's a useful debugging tool for the k8s admin. 

Here's an example. (Note: I've since changed the message.)

<img width="1022" alt="Screen Shot 2022-08-24 at 4 05 35 PM" src="https://user-images.githubusercontent.com/224251/186533191-32fc0f12-62a6-4089-b897-606c631403f4.png">

