### PR TITLE
refactor: Pin infra toolkit image for init containers

### DIFF
--- a/controllers/internal/fullnode/pod_builder.go
+++ b/controllers/internal/fullnode/pod_builder.go
@@ -232,7 +232,7 @@ const (
 	tmpDir       = workDir + "/.tmp"
 	tmpConfigDir = workDir + "/.config"
 
-	infraToolImage = "ghcr.io/strangelove-ventures/infra-toolkit"
+	infraToolImage = "ghcr.io/strangelove-ventures/infra-toolkit:v0.0.1"
 )
 
 var (


### PR DESCRIPTION
Now that we have a dedicated tag, it's much safer to pin the image vs. using latest which could have breaking changes in the future. 