### PR TITLE
feat: Volume Retention Policy

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -50,6 +50,15 @@ type FullNodeSpec struct {
 	// One PVC per replica mapped and mounted to a corresponding pod.
 	VolumeClaimTemplate PersistentVolumeClaimSpec `json:"volumeClaimTemplate"`
 
+	// Determines how to handle PVCs when pods are scaled down.
+	// One of 'Retain' or 'Delete'.
+	// If 'Delete', PVCs are deleted if pods are scaled down.
+	// If 'Retain', PVCs are not deleted. The admin must delete manually or are deleted if the CRD is deleted.
+	// If not set, defaults to 'Delete'.
+	// +kubebuilder:validation:Enum:=Retain;Delete
+	// +optional
+	RetentionPolicy *RetentionPolicy `json:"volumeRetentionPolicy"`
+
 	// Configure Operator created services. A singe rpc service is created for load balancing api, grpc, rpc, etc. requests.
 	// This allows a k8s admin to use the service in an Ingress, for example.
 	// Additionally, multiple p2p services are created for tendermint peer exchange.
@@ -187,22 +196,13 @@ type PersistentVolumeClaimSpec struct {
 	// This field is immutable. Updating this field requires manually deleting the PVC.
 	// +optional
 	VolumeMode *corev1.PersistentVolumeMode `json:"volumeMode"`
-
-	// Determines how to handle PVCs when pods are scaled down.
-	// One of 'Retain' or 'Delete'.
-	// If 'Delete', PVCs are deleted if pods are scaled down.
-	// If 'Retain', PVCs are not deleted. The admin must delete manually or are deleted if the CRD is deleted.
-	// If not set, defaults to 'Delete'.
-	// +kubebuilder:validation:Enum:=Retain;Delete
-	// +optional
-	RetainPolicy *PVCRetainPolicy `json:"retainPolicy"`
 }
 
-type PVCRetainPolicy string
+type RetentionPolicy string
 
 const (
-	PVCRetainPolicyRetain PVCRetainPolicy = "Retain"
-	PVCRetainPolicyDelete PVCRetainPolicy = "Delete"
+	RetentionPolicyRetain RetentionPolicy = "Retain"
+	RetentionPolicyDelete RetentionPolicy = "Delete"
 )
 
 // RolloutStrategy is an update strategy that can be shared between several Cosmos CRDs.

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -169,6 +169,11 @@ func (in *FullNodeSpec) DeepCopyInto(out *FullNodeSpec) {
 	in.PodTemplate.DeepCopyInto(&out.PodTemplate)
 	in.RolloutStrategy.DeepCopyInto(&out.RolloutStrategy)
 	in.VolumeClaimTemplate.DeepCopyInto(&out.VolumeClaimTemplate)
+	if in.RetentionPolicy != nil {
+		in, out := &in.RetentionPolicy, &out.RetentionPolicy
+		*out = new(RetentionPolicy)
+		**out = **in
+	}
 	in.Service.DeepCopyInto(&out.Service)
 }
 
@@ -209,11 +214,6 @@ func (in *PersistentVolumeClaimSpec) DeepCopyInto(out *PersistentVolumeClaimSpec
 	if in.VolumeMode != nil {
 		in, out := &in.VolumeMode, &out.VolumeMode
 		*out = new(corev1.PersistentVolumeMode)
-		**out = **in
-	}
-	if in.RetainPolicy != nil {
-		in, out := &in.RetainPolicy, &out.RetainPolicy
-		*out = new(PVCRetainPolicy)
 		**out = **in
 	}
 }

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -1372,16 +1372,6 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
-                  retainPolicy:
-                    description: Determines how to handle PVCs when pods are scaled
-                      down. One of 'Retain' or 'Delete'. If 'Delete', PVCs are deleted
-                      if pods are scaled down. If 'Retain', PVCs are not deleted.
-                      The admin must delete manually or are deleted if the CRD is
-                      deleted. If not set, defaults to 'Delete'.
-                    enum:
-                    - Retain
-                    - Delete
-                    type: string
                   storageClassName:
                     description: 'storageClassName is the name of the StorageClass
                       required by the claim. For proper pod scheduling, it''s highly
@@ -1401,6 +1391,16 @@ spec:
                 - resources
                 - storageClassName
                 type: object
+              volumeRetentionPolicy:
+                description: Determines how to handle PVCs when pods are scaled down.
+                  One of 'Retain' or 'Delete'. If 'Delete', PVCs are deleted if pods
+                  are scaled down. If 'Retain', PVCs are not deleted. The admin must
+                  delete manually or are deleted if the CRD is deleted. If not set,
+                  defaults to 'Delete'.
+                enum:
+                - Retain
+                - Delete
+                type: string
             required:
             - chain
             - podTemplate

--- a/controllers/internal/fullnode/pvc_control.go
+++ b/controllers/internal/fullnode/pvc_control.go
@@ -111,8 +111,8 @@ func (vc PVCControl) Reconcile(ctx context.Context, log logr.Logger, crd *cosmos
 }
 
 func (vc PVCControl) shouldRetain(crd *cosmosv1.CosmosFullNode) bool {
-	if policy := crd.Spec.VolumeClaimTemplate.RetainPolicy; policy != nil {
-		return *policy == cosmosv1.PVCRetainPolicyRetain
+	if policy := crd.Spec.RetentionPolicy; policy != nil {
+		return *policy == cosmosv1.RetentionPolicyRetain
 	}
 	return false
 }

--- a/controllers/internal/fullnode/pvc_control_test.go
+++ b/controllers/internal/fullnode/pvc_control_test.go
@@ -134,7 +134,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		require.Equal(t, updates[1].Spec.Resources, gotPVC.Spec.Resources)
 	})
 
-	t.Run("retain policy", func(t *testing.T) {
+	t.Run("retention policy", func(t *testing.T) {
 		var (
 			mDiff = mockPVCDiffer{
 				StubDeletes: buildPVCs(2),
@@ -144,7 +144,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 			control = NewPVCControl(&mClient)
 		)
 		crd.Namespace = namespace
-		crd.Spec.VolumeClaimTemplate.RetainPolicy = ptr(cosmosv1.PVCRetainPolicyRetain)
+		crd.Spec.RetentionPolicy = ptr(cosmosv1.RetentionPolicyRetain)
 		control.diffFactory = func(_, _ string, current, want []*corev1.PersistentVolumeClaim) pvcDiffer {
 			return mDiff
 		}
@@ -154,7 +154,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		require.Zero(t, mClient.DeleteCount)
 		require.False(t, requeue)
 
-		crd.Spec.VolumeClaimTemplate.RetainPolicy = ptr(cosmosv1.PVCRetainPolicyDelete)
+		crd.Spec.RetentionPolicy = ptr(cosmosv1.RetentionPolicyDelete)
 		requeue, err = control.Reconcile(ctx, nopLogger, &crd)
 		require.NoError(t, err)
 


### PR DESCRIPTION
The solves my own problem of wanting to scale replicas up and down without needing to download a snapshot every time. 

Now the user can modify that behavior. For testing, it's annoying to have to wait on snapshot downloads.