### PR TITLE
fix: Refactor instance override field name for clarity. 

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -484,10 +484,10 @@ type RPCServiceSpec struct {
 
 // InstanceOverridesSpec allows overriding an instance which is pod/pvc combo with an ordinal
 type InstanceOverridesSpec struct {
-	// If true, controller will not restart the pod if it's deleted. This is useful for actions such as debugging the PVC
-	// or deleting the PVC.
+	// If true, controller will not create or restart the pod for this instance.
+	// This is useful for actions such as debugging the PVC or deleting the PVC.
 	// +optional
-	PreventPodRestart bool `json:"preventPodRestart"`
+	DisablePod bool `json:"disablePod"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -244,10 +244,10 @@ spec:
                   description: InstanceOverridesSpec allows overriding an instance
                     which is pod/pvc combo with an ordinal
                   properties:
-                    preventPodRestart:
-                      description: If true, controller will not restart the pod if
-                        it's deleted. This is useful for actions such as debugging
-                        the PVC or deleting the PVC.
+                    disablePod:
+                      description: If true, controller will not create or restart
+                        the pod for this instance. This is useful for actions such
+                        as debugging the PVC or deleting the PVC.
                       type: boolean
                   type: object
                 description: 'Allows overriding an instance on a case-by-case basis.

--- a/controllers/internal/fullnode/pod_state.go
+++ b/controllers/internal/fullnode/pod_state.go
@@ -14,7 +14,7 @@ func PodState(crd *cosmosv1.CosmosFullNode) []*corev1.Pod {
 	)
 	for i := int32(0); i < crd.Spec.Replicas; i++ {
 		pod := builder.WithOrdinal(i).Build()
-		if overrides[pod.Name].PreventPodRestart {
+		if overrides[pod.Name].DisablePod {
 			continue
 		}
 		pods = append(pods, pod)

--- a/controllers/internal/fullnode/pod_state_test.go
+++ b/controllers/internal/fullnode/pod_state_test.go
@@ -50,8 +50,8 @@ func TestPodState(t *testing.T) {
 			Spec: cosmosv1.FullNodeSpec{
 				Replicas: 6,
 				InstanceOverrides: map[string]cosmosv1.InstanceOverridesSpec{
-					"agoric-2": {PreventPodRestart: true},
-					"agoric-4": {PreventPodRestart: true},
+					"agoric-2": {DisablePod: true},
+					"agoric-4": {DisablePod: true},
 				},
 			},
 		}


### PR DESCRIPTION
`PreventPodRestart` indicates the pod will be created but not restarted. The reality is the pod will never be created if this override is set to true. Therefore, `DisablePod` I feel is a better, clearer name. 