### PR TITLE
refactor: Remove secret necessary for pulling docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,13 +127,6 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
-GH_PAT ?= $(error Please set GH_PAT for you personal access token to log into ghcr)
-GH_USER ?= $(error Please set GH_USER to log into ghcr)
-DOCKER_EMAIL ?= infra@strangelove.ventures
-.PHONY: regcred
-regcred: ## Installs an image pull secret using the K8s cluster specified in ~/.kube/config.
-	@kubectl -n cosmos-operator-system create secret docker-registry regcred --docker-server=ghcr.io/strangelove-ventures/cosmos-operator --docker-username=$(GH_USER) --docker-password=$(GH_PAT) --docker-email=infra@strangelove.ventures
-
 ##@ Build Dependencies
 
 ## Location to install dependencies to

--- a/README.md
+++ b/README.md
@@ -136,15 +136,7 @@ Create a [PAT on Github](https://docs.github.com/en/authentication/keeping-your-
 printenv GH_PAT | docker login ghcr.io -u <your GH username> --password-stdin 
 ```
 
-2. If a new cluster, install image pull secret.
-
-*If project is now open source, omit and delete this step!*
-
-```sh
-GH_USER=<your Github username> GH_PAT=<personal access token> make regred
-```
-
-3. Deploy a prerelease.
+2. Deploy a prerelease.
 
 *Warning: Make sure you're kube context is set appropriately, so you don't install in the wrong cluster!*
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,8 +62,5 @@ spec:
           requests:
             cpu: 50m
             memory: 64Mi
-      # TODO: Delete imagePullSecrets once open sourced.
-      imagePullSecrets:
-        - name: regcred
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
GHCR packages are now public per team decision. Pulling requires no credentials. 

You still need to auth to push images to GHCR though. 