### PR TITLE
fix: Add --chain-id to init command

### DIFF
--- a/controllers/internal/fullnode/pod_builder.go
+++ b/controllers/internal/fullnode/pod_builder.go
@@ -240,6 +240,7 @@ func initContainers(crd *cosmosv1.CosmosFullNode, moniker string) []corev1.Conta
 	binary := crd.Spec.ChainConfig.Binary
 	genesisCmd, genesisArgs := DownloadGenesisCommand(crd.Spec.ChainConfig)
 
+	initCmd := fmt.Sprintf("%s init %s --chain-id %s", binary, moniker, crd.Spec.ChainConfig.ChainID)
 	required := []corev1.Container{
 		{
 			Name:    "chain-init",
@@ -250,7 +251,7 @@ func initContainers(crd *cosmosv1.CosmosFullNode, moniker string) []corev1.Conta
 set -eu
 if [ ! -d "$CHAIN_HOME/data" ]; then
 	echo "Initializing chain..."
-	%s init %s --home "$CHAIN_HOME"
+	%s --home "$CHAIN_HOME"
 	# Remove because downstream containers check the presence of this file.
 	rm "$GENESIS_FILE"
 else
@@ -258,8 +259,8 @@ else
 fi
 
 echo "Initializing into tmp dir for downstream processing..."
-%s init %s --home "$HOME/.tmp"
-`, binary, moniker, binary, moniker),
+%s --home "$HOME/.tmp"
+`, initCmd, initCmd),
 			},
 			Env:             envVars,
 			ImagePullPolicy: tpl.ImagePullPolicy,

--- a/controllers/internal/fullnode/pod_builder_test.go
+++ b/controllers/internal/fullnode/pod_builder_test.go
@@ -181,6 +181,7 @@ func TestPodBuilder(t *testing.T) {
 	t.Run("containers", func(t *testing.T) {
 		crd := defaultCRD()
 		const wantWrkDir = "/home/operator"
+		crd.Spec.ChainConfig.ChainID = "osmosis-123"
 		crd.Spec.ChainConfig.Binary = "osmosisd"
 		crd.Spec.ChainConfig.SnapshotURL = ptr("https://example.com/snapshot.tar")
 		crd.Spec.PodTemplate.Image = "main-image:v1.2.3"
@@ -239,8 +240,8 @@ func TestPodBuilder(t *testing.T) {
 		}
 
 		initCont := pod.Spec.InitContainers[0]
-		require.Contains(t, initCont.Args[1], `osmosisd init osmosis-6 --home "$CHAIN_HOME"`)
-		require.Contains(t, initCont.Args[1], `osmosisd init osmosis-6 --home "$HOME/.tmp"`)
+		require.Contains(t, initCont.Args[1], `osmosisd init osmosis-6 --chain-id osmosis-123 --home "$CHAIN_HOME"`)
+		require.Contains(t, initCont.Args[1], `osmosisd init osmosis-6 --chain-id osmosis-123 --home "$HOME/.tmp"`)
 
 		mergeConfig := pod.Spec.InitContainers[2]
 		// The order of config-merge arguments is important. Rightmost takes precedence.


### PR DESCRIPTION
An oversight by me. 

Some chains don't care if it's missing (cosmshub and osmosis). But evmos does. 

Otherwise, evmosd exits with:

```
│ chain-init Skipping chain init; already initialized.                                                                                                                                                  │
│ chain-init Initializing into tmp dir for downstream processing...                                                                                                                                     │
│ chain-init Error: invalid chain-id format:                                                                                                                                                            │  
```