### PR TITLE
fix(HostedSnapshot): Update role to manage volume snapshots

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -72,3 +72,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/hostedsnapshot_controller.go
+++ b/controllers/hostedsnapshot_controller.go
@@ -38,6 +38,7 @@ type HostedSnapshotReconciler struct {
 //+kubebuilder:rbac:groups=cosmos.strange.love,resources=hostedsnapshots,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cosmos.strange.love,resources=hostedsnapshots/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=cosmos.strange.love,resources=hostedsnapshots/finalizers,verbs=update
+//+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
One flaw with kubebuilder is when developing locally, there is no role so it always works. So it's easy to forget this step.

However, when deploying it for real, you can run into permissions issues. 