### PR TITLE
refactor(StatefulJob): Remove container volume mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ View a [minimal example](./config/samples/cosmos_v1_cosmosfullnode.yaml) or a [f
 
 API Version: v1alpha1
 
-The StatefulJob is a means to process persistent data from a recent [VolumeSnapshot](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) of a PVC created from a CosmosFullNode. 
-It periodically creates a job and PVC using the most recent VolumeSnapshot as its data source. It mounts the PVC as a volume into all of the job's pods. 
+The StatefulJob is a means to process persistent data from a recent [VolumeSnapshot](https://kubernetes.io/docs/concepts/storage/volume-snapshots/).
+It periodically creates a job and PVC using the most recent VolumeSnapshot as its data source. It mounts the PVC as volume "snapshot" into the job's pod.
+The user must configure container volume mounts.
 It's similar to a CronJob but does not offer advanced scheduling via a crontab. 
 
 Strangelove uses it to compress and upload snapshots of chain data.

--- a/config/samples/cosmos_v1alpha1_statefuljob.yaml
+++ b/config/samples/cosmos_v1alpha1_statefuljob.yaml
@@ -23,6 +23,9 @@ spec:
           - ls
         args:
           - "/home/operator/cosmos"
+        volumeMounts:
+          - mountPath: /home/operator/cosmos
+            name: snapshot # StatefulJob always injects volume "snapshot" into pod spec.
   # required
   volumeClaimTemplate:
     storageClassName: premium-rwo

--- a/controllers/internal/statefuljob/job.go
+++ b/controllers/internal/statefuljob/job.go
@@ -39,9 +39,8 @@ func BuildJobs(crd *cosmosalpha.StatefulJob) []*batchv1.Job {
 		job.Spec.TTLSecondsAfterFinished = v
 	}
 
-	const volName = "snapshot"
 	job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, corev1.Volume{
-		Name: volName,
+		Name: "snapshot",
 		VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 			ClaimName: ResourceName(crd),
 		}},
@@ -49,25 +48,6 @@ func BuildJobs(crd *cosmosalpha.StatefulJob) []*batchv1.Job {
 
 	if job.Spec.Template.Spec.RestartPolicy == "" {
 		job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
-	}
-
-	const chainHome = "/home/operator/cosmos"
-	var (
-		mount = corev1.VolumeMount{
-			Name:      volName,
-			MountPath: chainHome,
-		}
-		envVar = corev1.EnvVar{Name: "CHAIN_HOME", Value: chainHome}
-	)
-
-	for i := range job.Spec.Template.Spec.Containers {
-		job.Spec.Template.Spec.Containers[i].VolumeMounts = append(job.Spec.Template.Spec.Containers[i].VolumeMounts, mount)
-		job.Spec.Template.Spec.Containers[i].Env = append(job.Spec.Template.Spec.Containers[i].Env, envVar)
-	}
-
-	for i := range job.Spec.Template.Spec.InitContainers {
-		job.Spec.Template.Spec.InitContainers[i].VolumeMounts = append(job.Spec.Template.Spec.InitContainers[i].VolumeMounts, mount)
-		job.Spec.Template.Spec.InitContainers[i].Env = append(job.Spec.Template.Spec.InitContainers[i].Env, envVar)
 	}
 
 	return []*batchv1.Job{&job}


### PR DESCRIPTION
This was a result of a pairing session. The StatefulJob is assuming too much on what the VolumeSnapshot contains. 

The VolumeSnapshot may be from any PVC, not just ones created from CosmosFullNode.