### PR TITLE
refactor(StatefulJob): Remove prefix from resource names

### DIFF
--- a/controllers/internal/statefuljob/active_job_test.go
+++ b/controllers/internal/statefuljob/active_job_test.go
@@ -35,7 +35,7 @@ func TestFindActiveJob(t *testing.T) {
 		getter := mockGetter(func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			require.NotNil(t, ctx)
 			require.Equal(t, "test-ns", key.Namespace)
-			require.Equal(t, "stateful-job-test", key.Name)
+			require.Equal(t, "test", key.Name)
 			require.Empty(t, opts)
 
 			ref := obj.(*batchv1.Job)

--- a/controllers/internal/statefuljob/job_test.go
+++ b/controllers/internal/statefuljob/job_test.go
@@ -36,7 +36,7 @@ func TestBuildJobs(t *testing.T) {
 		got := jobs[0]
 
 		require.Equal(t, "test", got.Namespace)
-		require.Equal(t, "stateful-job-axelar", got.Name)
+		require.Equal(t, "axelar", got.Name)
 
 		wantLabels := map[string]string{
 			"app.kubernetes.io/created-by": "cosmos-operator",
@@ -90,6 +90,6 @@ func TestBuildJobs(t *testing.T) {
 		gotVol, err := lo.Last(got.Spec.Template.Spec.Volumes)
 		require.NoError(t, err)
 		require.Equal(t, "snapshot", gotVol.Name)
-		require.Equal(t, "stateful-job-cosmoshub", gotVol.VolumeSource.PersistentVolumeClaim.ClaimName)
+		require.Equal(t, "cosmoshub", gotVol.VolumeSource.PersistentVolumeClaim.ClaimName)
 	})
 }

--- a/controllers/internal/statefuljob/pvc_test.go
+++ b/controllers/internal/statefuljob/pvc_test.go
@@ -44,7 +44,7 @@ func TestBuildPVCs(t *testing.T) {
 
 		got := pvcs[0]
 
-		require.Equal(t, "stateful-job-my-test", got.Name)
+		require.Equal(t, "my-test", got.Name)
 		require.Equal(t, "test", got.Namespace)
 
 		require.Equal(t, "my-snapshot", got.Spec.DataSource.Name)

--- a/controllers/internal/statefuljob/resource.go
+++ b/controllers/internal/statefuljob/resource.go
@@ -7,5 +7,5 @@ import (
 
 // ResourceName is the name of all resources created by the controller.
 func ResourceName(crd *cosmosalpha.StatefulJob) string {
-	return kube.ToName("stateful-job-" + crd.Name)
+	return kube.ToName(crd.Name)
 }

--- a/controllers/internal/statefuljob/resource_test.go
+++ b/controllers/internal/statefuljob/resource_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestResourceName(t *testing.T) {
+	t.Parallel()
+
 	var crd cosmosalpha.StatefulJob
 	crd.Name = "test"
 

--- a/controllers/internal/statefuljob/resource_test.go
+++ b/controllers/internal/statefuljob/resource_test.go
@@ -12,10 +12,9 @@ func TestResourceName(t *testing.T) {
 	var crd cosmosalpha.StatefulJob
 	crd.Name = "test"
 
-	require.Equal(t, "stateful-job-test", ResourceName(&crd))
+	require.Equal(t, "test", ResourceName(&crd))
 
 	crd.Name = strings.Repeat("long", 100)
 	name := ResourceName(&crd)
 	require.LessOrEqual(t, 253, len(name))
-	require.Contains(t, name, "stateful-job-")
 }


### PR DESCRIPTION
This is a backwards breaking change. (As a reminder, StatefulJob is alpha.)

The motivation for this change is no other k8s controllers prefix in this manner, so I'm moving to k8s conventions. 

We only have one deployment using StatefulJob so far, so I will manually babysit that one.

The result of this change is a potential 2 job/pvc combos due to not cleaning up the resources with the now deprecated prefix `stateful-job`. I'll manually clean up the old resources. 