### PR TITLE
refactor(CosmosFullNode): Change p2p service default from 3 to 1

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -487,7 +487,7 @@ const (
 type ServiceSpec struct {
 	// Maximum number of p2p services to create for tendermint peer exchange.
 	// The public endpoint is set as the "p2p.external_address" in the tendermint config.toml.
-	// If not set, defaults to 3.
+	// If not set, defaults to 1.
 	// +kubebuilder:validation:Minimum:=0
 	// +optional
 	MaxP2PExternalAddresses *int32 `json:"maxP2PExternalAddresses"`

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -1429,7 +1429,7 @@ spec:
                   maxP2PExternalAddresses:
                     description: Maximum number of p2p services to create for tendermint
                       peer exchange. The public endpoint is set as the "p2p.external_address"
-                      in the tendermint config.toml. If not set, defaults to 3.
+                      in the tendermint config.toml. If not set, defaults to 1.
                     format: int32
                     minimum: 0
                     type: integer

--- a/controllers/internal/fullnode/service_builder.go
+++ b/controllers/internal/fullnode/service_builder.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const maxP2PServiceDefault = 3
+const maxP2PServiceDefault = 1
 
 // BuildServices returns a list of services given the crd.
 //

--- a/controllers/internal/fullnode/service_builder_test.go
+++ b/controllers/internal/fullnode/service_builder_test.go
@@ -90,32 +90,6 @@ func TestBuildServices(t *testing.T) {
 		require.Equal(t, 1, len(got))
 	})
 
-	t.Run("p2p max external addresses", func(t *testing.T) {
-		crd := defaultCRD()
-		crd.Spec.Replicas = 10
-
-		for i := 0; i < 5; i++ {
-			crd.Spec.Service.MaxP2PExternalAddresses = ptr(int32(i))
-			svcs := BuildServices(&crd)
-
-			got := lo.Filter(svcs, func(s *corev1.Service, _ int) bool {
-				return s.Labels[kube.ComponentLabel] == "p2p"
-			})
-
-			require.Equal(t, i, len(got))
-		}
-
-		crd.Spec.Replicas = 1
-		crd.Spec.Service.MaxP2PExternalAddresses = ptr(int32(2))
-
-		svcs := BuildServices(&crd)
-		got := lo.Filter(svcs, func(s *corev1.Service, _ int) bool {
-			return s.Labels[kube.ComponentLabel] == "p2p"
-		})
-
-		require.Equal(t, 1, len(got))
-	})
-
 	t.Run("rpc service", func(t *testing.T) {
 		crd := defaultCRD()
 		crd.Spec.Replicas = 1

--- a/controllers/internal/fullnode/service_builder_test.go
+++ b/controllers/internal/fullnode/service_builder_test.go
@@ -25,7 +25,7 @@ func TestBuildServices(t *testing.T) {
 		crd.Spec.PodTemplate.Image = "terra:v6.0.0"
 		svcs := BuildServices(&crd)
 
-		require.Equal(t, 4, len(svcs)) // Includes single rpc service.
+		require.Equal(t, 2, len(svcs)) // Includes single rpc service.
 
 		p2p := svcs[0]
 		require.Equal(t, "terra-p2p-0", p2p.Name)
@@ -59,9 +59,6 @@ func TestBuildServices(t *testing.T) {
 		}
 
 		require.Equal(t, wantSpec, p2p.Spec)
-
-		p2p = svcs[1]
-		require.Equal(t, "terra-p2p-1", p2p.Name)
 	})
 
 	t.Run("p2p max external addresses", func(t *testing.T) {

--- a/controllers/internal/fullnode/service_control_test.go
+++ b/controllers/internal/fullnode/service_control_test.go
@@ -32,7 +32,7 @@ func TestServiceControl_Reconcile(t *testing.T) {
 		control.diffFactory = func(revisionLabelKey string, current, want []*corev1.Service) svcDiffer {
 			require.Equal(t, "app.kubernetes.io/revision", revisionLabelKey)
 			require.Equal(t, 4, len(current))
-			require.EqualValues(t, crd.Spec.Replicas+1, len(want)) // Includes rpc service.
+			require.EqualValues(t, 2, len(want)) // 1 p2p service and the rpc service.
 
 			return mockSvcDiffer{
 				StubCreates: []*corev1.Service{{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"}}},


### PR DESCRIPTION
Each p2p service creates external resources on the cloud provider (ip addresses, load balancers, etc). Those are not free. So I'm opting to prioritize infra costs and quotas over more p2p peers. 

The user can optionally increase this setting if they want to expose more p2p peers. 