### PR TITLE
feat(ScheduledVolumeSnapshot): Delete snapshots that exceed limit 

### DIFF
--- a/api/v1alpha1/scheduledvolumesnapshot_types.go
+++ b/api/v1alpha1/scheduledvolumesnapshot_types.go
@@ -69,9 +69,9 @@ type ScheduledVolumeSnapshotSpec struct {
 	MinAvailable int32 `json:"minAvailable"`
 
 	// The number of recent VolumeSnapshots to keep.
-	// Default is 3.
+	// Defaults to 3.
 	// +optional
-	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Minimum:=1
 	Limit int32 `json:"limit"`
 }
 

--- a/config/crd/bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
+++ b/config/crd/bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
@@ -64,10 +64,10 @@ spec:
                 - namespace
                 type: object
               limit:
-                description: The number of recent VolumeSnapshots to keep. Default
-                  is 3.
+                description: The number of recent VolumeSnapshots to keep. Defaults
+                  to 3.
                 format: int32
-                minimum: 0
+                minimum: 1
                 type: integer
               minAvailable:
                 description: 'Minimum number of CosmosFullNode pods that must be ready

--- a/controllers/internal/volsnapshot/vol_snapshot_control_test.go
+++ b/controllers/internal/volsnapshot/vol_snapshot_control_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	"github.com/samber/lo"
 	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
 	cosmosalpha "github.com/strangelove-ventures/cosmos-operator/api/v1alpha1"
 	"github.com/strangelove-ventures/cosmos-operator/controllers/internal/fullnode"
@@ -18,16 +21,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type mockClient struct {
+type mockPodClient struct {
 	GotListOpts []client.ListOption
-	PodItems    []corev1.Pod
+	Items       []corev1.Pod
 	ListErr     error
 
 	GotCreateObj client.Object
 	CreateErr    error
 }
 
-func (m *mockClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+func (m *mockPodClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
 	if ctx == nil {
 		panic("nil context")
 	}
@@ -38,13 +41,17 @@ func (m *mockClient) Create(ctx context.Context, obj client.Object, opts ...clie
 	return m.CreateErr
 }
 
-func (m *mockClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+func (m *mockPodClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	if ctx == nil {
 		panic("nil context")
 	}
 	m.GotListOpts = opts
-	list.(*corev1.PodList).Items = m.PodItems
+	list.(*corev1.PodList).Items = m.Items
 	return m.ListErr
+}
+
+func (m *mockPodClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	panic("delete should not be called")
 }
 
 type mockPodFinder func(ctx context.Context, candidates []*corev1.Pod) (*corev1.Pod, error)
@@ -74,8 +81,8 @@ func TestVolumeSnapshotControl_FindCandidate(t *testing.T) {
 		for i := range pods {
 			pods[i].Status.Conditions = []corev1.PodCondition{readyCondition}
 		}
-		var mClient mockClient
-		mClient.PodItems = pods
+		var mClient mockPodClient
+		mClient.Items = pods
 
 		var fullnodeCRD cosmosv1.CosmosFullNode
 		fullnodeCRD.Name = "osmosis"
@@ -112,8 +119,8 @@ func TestVolumeSnapshotControl_FindCandidate(t *testing.T) {
 		var pod corev1.Pod
 		pod.Name = "found-me"
 		pod.Status.Conditions = []corev1.PodCondition{readyCondition}
-		var mClient mockClient
-		mClient.PodItems = []corev1.Pod{pod}
+		var mClient mockPodClient
+		mClient.Items = []corev1.Pod{pod}
 
 		control := NewVolumeSnapshotControl(&mClient, mockPodFinder(func(ctx context.Context, candidates []*corev1.Pod) (*corev1.Pod, error) {
 			return &pod, nil
@@ -129,7 +136,7 @@ func TestVolumeSnapshotControl_FindCandidate(t *testing.T) {
 	})
 
 	t.Run("list error", func(t *testing.T) {
-		var mClient mockClient
+		var mClient mockPodClient
 		mClient.ListErr = errors.New("no list for you")
 		control := NewVolumeSnapshotControl(&mClient, panicFinder)
 
@@ -144,8 +151,8 @@ func TestVolumeSnapshotControl_FindCandidate(t *testing.T) {
 		for i := range pods {
 			pods[i].Status.Conditions = []corev1.PodCondition{readyCondition}
 		}
-		var mClient mockClient
-		mClient.PodItems = pods
+		var mClient mockPodClient
+		mClient.Items = pods
 
 		control := NewVolumeSnapshotControl(&mClient, mockPodFinder(func(ctx context.Context, candidates []*corev1.Pod) (*corev1.Pod, error) {
 			return nil, errors.New("pod sync error")
@@ -170,8 +177,8 @@ func TestVolumeSnapshotControl_FindCandidate(t *testing.T) {
 			{make([]corev1.Pod, 3), "2 or more pods must be ready to prevent downtime, found 0 ready"},      // no pods ready
 			{[]corev1.Pod{readyPod, {}}, "2 or more pods must be ready to prevent downtime, found 1 ready"}, // 1 pod ready
 		} {
-			var mClient mockClient
-			mClient.PodItems = tt.Pods
+			var mClient mockPodClient
+			mClient.Items = tt.Pods
 
 			control := NewVolumeSnapshotControl(&mClient, panicFinder)
 
@@ -189,7 +196,7 @@ func TestVolumeSnapshotControl_CreateSnapshot(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("happy path", func(t *testing.T) {
-		var mClient mockClient
+		var mClient mockPodClient
 		control := NewVolumeSnapshotControl(&mClient, panicFinder)
 		// Use time.Local to ensure we format with UTC.
 		now := time.Date(2022, time.September, 1, 2, 3, 0, 0, time.UTC)
@@ -227,9 +234,10 @@ func TestVolumeSnapshotControl_CreateSnapshot(t *testing.T) {
 		require.Nil(t, got.Spec.Source.VolumeSnapshotContentName)
 
 		wantLabels := map[string]string{
-			"test":               "labels",
-			kube.ControllerLabel: "cosmos-operator",
-			kube.ComponentLabel:  "ScheduledVolumeSnapshot",
+			"test":                       "labels",
+			kube.ControllerLabel:         "cosmos-operator",
+			kube.ComponentLabel:          "ScheduledVolumeSnapshot",
+			"cosmos.strange.love/source": "my-snapshot",
 		}
 		require.Equal(t, wantLabels, got.Labels)
 
@@ -241,9 +249,10 @@ func TestVolumeSnapshotControl_CreateSnapshot(t *testing.T) {
 	})
 
 	t.Run("nil pod labels", func(t *testing.T) {
-		var mClient mockClient
+		var mClient mockPodClient
 		control := NewVolumeSnapshotControl(&mClient, panicFinder)
 		var crd cosmosalpha.ScheduledVolumeSnapshot
+		crd.Name = "cosmoshub"
 
 		err := control.CreateSnapshot(ctx, &crd, Candidate{})
 
@@ -255,12 +264,13 @@ func TestVolumeSnapshotControl_CreateSnapshot(t *testing.T) {
 		wantLabels := map[string]string{
 			kube.ControllerLabel: "cosmos-operator",
 			kube.ComponentLabel:  "ScheduledVolumeSnapshot",
+			cosmosSourceLabel:    "cosmoshub",
 		}
 		require.Equal(t, wantLabels, got.Labels)
 	})
 
 	t.Run("create error", func(t *testing.T) {
-		var mClient mockClient
+		var mClient mockPodClient
 		mClient.CreateErr = errors.New("boom")
 		control := NewVolumeSnapshotControl(&mClient, panicFinder)
 		var crd cosmosalpha.ScheduledVolumeSnapshot
@@ -268,5 +278,199 @@ func TestVolumeSnapshotControl_CreateSnapshot(t *testing.T) {
 
 		require.Error(t, err)
 		require.EqualError(t, err, "boom")
+	})
+}
+
+type mockVolumeSnapshotClient struct {
+	GotListOpts []client.ListOption
+	Items       []snapshotv1.VolumeSnapshot
+	ListErr     error
+
+	DeletedObjs []*snapshotv1.VolumeSnapshot
+	DeleteErr   error
+}
+
+func (m *mockVolumeSnapshotClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	panic("create should not be called")
+}
+
+func (m *mockVolumeSnapshotClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if ctx == nil {
+		panic("nil context")
+	}
+	m.GotListOpts = opts
+	list.(*snapshotv1.VolumeSnapshotList).Items = m.Items
+	return m.ListErr
+}
+
+func (m *mockVolumeSnapshotClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if ctx == nil {
+		panic("nil context")
+	}
+	m.DeletedObjs = append(m.DeletedObjs, obj.(*snapshotv1.VolumeSnapshot))
+	return m.DeleteErr
+}
+
+func TestVolumeSnapshotControl_DeleteOldSnapshots(t *testing.T) {
+	t.Parallel()
+	rand.Seed(time.Now().UnixNano())
+
+	ctx := context.Background()
+
+	t.Run("happy path - custom limit", func(t *testing.T) {
+		now := time.Now()
+		const (
+			limit      = 5
+			additional = 3
+		)
+
+		var mClient mockVolumeSnapshotClient
+		for i := 0; i < limit+additional; i++ {
+			creation := metav1.NewTime(now.Add(time.Duration(i) * time.Second))
+			mClient.Items = append(mClient.Items, snapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{Name: strconv.Itoa(i)},
+				Status: &snapshotv1.VolumeSnapshotStatus{
+					CreationTime: &creation,
+				},
+			})
+		}
+
+		// Nil status should be ignored.
+		mClient.Items = append(mClient.Items, snapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{Name: "should be filtered out 1"},
+			Status:     nil,
+		})
+		// Nil status.creationTime should be ignored.
+		mClient.Items = append(mClient.Items, snapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{Name: "should be filtered out 2"},
+			Status:     &snapshotv1.VolumeSnapshotStatus{},
+		})
+
+		lo.Shuffle(mClient.Items)
+
+		var crd cosmosalpha.ScheduledVolumeSnapshot
+		crd.Name = "agoric"
+		crd.Namespace = "default"
+		crd.Spec.Limit = int32(limit)
+
+		control := NewVolumeSnapshotControl(&mClient, panicFinder)
+		err := control.DeleteOldSnapshots(ctx, &crd)
+
+		require.NoError(t, err)
+
+		require.Len(t, mClient.GotListOpts, 2)
+		var listOpt client.ListOptions
+		for _, opt := range mClient.GotListOpts {
+			opt.ApplyToList(&listOpt)
+		}
+		require.Zero(t, listOpt.Limit)
+		require.Equal(t, "default", listOpt.Namespace)
+		require.Equal(t, "cosmos.strange.love/source=agoric", listOpt.LabelSelector.String())
+
+		require.EqualValues(t, additional, len(mClient.DeletedObjs))
+
+		got := lo.Map(mClient.DeletedObjs, func(item *snapshotv1.VolumeSnapshot, _ int) string {
+			return item.Name
+		})
+		require.ElementsMatch(t, []string{"0", "1", "2"}, got)
+	})
+
+	t.Run("happy path - default limit", func(t *testing.T) {
+		now := time.Now()
+		const total = 5
+
+		var mClient mockVolumeSnapshotClient
+		for i := 0; i < total; i++ {
+			creation := metav1.NewTime(now.Add(time.Duration(i) * time.Second))
+			mClient.Items = append(mClient.Items, snapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{Name: strconv.Itoa(i)},
+				Status: &snapshotv1.VolumeSnapshotStatus{
+					CreationTime: &creation,
+				},
+			})
+		}
+
+		lo.Shuffle(mClient.Items)
+
+		var crd cosmosalpha.ScheduledVolumeSnapshot
+		control := NewVolumeSnapshotControl(&mClient, panicFinder)
+		err := control.DeleteOldSnapshots(ctx, &crd)
+
+		require.NoError(t, err)
+
+		require.EqualValues(t, 2, len(mClient.DeletedObjs))
+
+		got := lo.Map(mClient.DeletedObjs, func(item *snapshotv1.VolumeSnapshot, _ int) string {
+			return item.Name
+		})
+		require.ElementsMatch(t, []string{"0", "1"}, got)
+	})
+
+	t.Run("happy path - under limit", func(t *testing.T) {
+		now := metav1.Now()
+		const total = 5
+
+		var mClient mockVolumeSnapshotClient
+		for i := 0; i < total; i++ {
+			mClient.Items = append(mClient.Items, snapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{Name: strconv.Itoa(i)},
+				Status: &snapshotv1.VolumeSnapshotStatus{
+					CreationTime: &now,
+				},
+			})
+		}
+
+		var crd cosmosalpha.ScheduledVolumeSnapshot
+		crd.Spec.Limit = total + 1
+		control := NewVolumeSnapshotControl(&mClient, panicFinder)
+		err := control.DeleteOldSnapshots(ctx, &crd)
+
+		require.NoError(t, err)
+		require.Empty(t, mClient.DeletedObjs)
+	})
+
+	t.Run("happy path - no items", func(t *testing.T) {
+		var mClient mockVolumeSnapshotClient
+		var crd cosmosalpha.ScheduledVolumeSnapshot
+		control := NewVolumeSnapshotControl(&mClient, panicFinder)
+		err := control.DeleteOldSnapshots(ctx, &crd)
+
+		require.NoError(t, err)
+		require.Empty(t, mClient.DeletedObjs)
+	})
+
+	t.Run("list error", func(t *testing.T) {
+		var mClient mockVolumeSnapshotClient
+		mClient.ListErr = errors.New("boom")
+		var crd cosmosalpha.ScheduledVolumeSnapshot
+		control := NewVolumeSnapshotControl(&mClient, panicFinder)
+		err := control.DeleteOldSnapshots(ctx, &crd)
+
+		require.Error(t, err)
+		require.EqualError(t, err, "list volume snapshots: boom")
+	})
+
+	t.Run("delete errors", func(t *testing.T) {
+		now := metav1.Now()
+		const total = 3
+
+		var mClient mockVolumeSnapshotClient
+		mClient.DeleteErr = errors.New("oops")
+		for i := 0; i < total; i++ {
+			mClient.Items = append(mClient.Items, snapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{Name: strconv.Itoa(i)},
+				Status: &snapshotv1.VolumeSnapshotStatus{
+					CreationTime: &now,
+				},
+			})
+		}
+
+		var crd cosmosalpha.ScheduledVolumeSnapshot
+		crd.Spec.Limit = 1
+		control := NewVolumeSnapshotControl(&mClient, panicFinder)
+		err := control.DeleteOldSnapshots(ctx, &crd)
+
+		require.Error(t, err)
+		require.EqualError(t, err, "delete 1: oops; delete 0: oops")
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/lo v1.37.0
 	github.com/stretchr/testify v1.8.1
+	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/exp v0.0.0-20220921164117-439092de6870
 	golang.org/x/sync v0.1.0
@@ -64,7 +65,6 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect


### PR DESCRIPTION
Closes https://github.com/strangelove-ventures/cosmos-operator/issues/164

The limit default is 3 (arbitrarily chosen). I was trying to balance between usefulness and costs. 

I'm letting this new snapshot feature run over the weekend every 15 minutes as a torture test. 