### PR TITLE
feat: Add printer columns to all CRDs

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -605,6 +605,7 @@ type VolumeSnapshotSpec struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 
 // CosmosFullNode is the Schema for the cosmosfullnodes API
 type CosmosFullNode struct {

--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -606,6 +606,7 @@ type VolumeSnapshotSpec struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // CosmosFullNode is the Schema for the cosmosfullnodes API
 type CosmosFullNode struct {

--- a/api/v1alpha1/scheduledvolumesnapshot_types.go
+++ b/api/v1alpha1/scheduledvolumesnapshot_types.go
@@ -161,6 +161,7 @@ type VolumeSnapshotStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ScheduledVolumeSnapshot is the Schema for the scheduledvolumesnapshots API
 type ScheduledVolumeSnapshot struct {

--- a/api/v1alpha1/scheduledvolumesnapshot_types.go
+++ b/api/v1alpha1/scheduledvolumesnapshot_types.go
@@ -160,6 +160,7 @@ type VolumeSnapshotStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 
 // ScheduledVolumeSnapshot is the Schema for the scheduledvolumesnapshots API
 type ScheduledVolumeSnapshot struct {

--- a/api/v1alpha1/statefuljob_types.go
+++ b/api/v1alpha1/statefuljob_types.go
@@ -122,6 +122,7 @@ type StatefulJobStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // StatefulJob is the Schema for the statefuljobs API
 type StatefulJob struct {

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -19,6 +19,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -15,7 +15,11 @@ spec:
     singular: cosmosfullnode
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: CosmosFullNode is the Schema for the cosmosfullnodes API

--- a/config/crd/bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
+++ b/config/crd/bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
@@ -19,6 +19,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
+++ b/config/crd/bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
@@ -15,7 +15,11 @@ spec:
     singular: scheduledvolumesnapshot
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ScheduledVolumeSnapshot is the Schema for the scheduledvolumesnapshots

--- a/config/crd/bases/cosmos.strange.love_statefuljobs.yaml
+++ b/config/crd/bases/cosmos.strange.love_statefuljobs.yaml
@@ -15,7 +15,11 @@ spec:
     singular: statefuljob
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: StatefulJob is the Schema for the statefuljobs API


### PR DESCRIPTION
Closes https://github.com/strangelove-ventures/cosmos-operator/issues/175

Controls how k8s clients (like kubectl) pretty print columns. 

Now it will show something like this:

<img width="841" alt="Screenshot 2023-01-06 at 4 16 52 PM" src="https://user-images.githubusercontent.com/224251/211116239-4d8848f5-706e-4d60-875b-b098a588fc39.png">
