### PR TITLE
fix: Remove readiness probes for sentries

### DIFF
--- a/controllers/internal/fullnode/pod_builder.go
+++ b/controllers/internal/fullnode/pod_builder.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var bufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
@@ -35,9 +36,11 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 		panic(errors.New("nil CosmosFullNode"))
 	}
 
-	tpl := crd.Spec.PodTemplate
-
-	startCmd, startArgs := startCmdAndArgs(crd)
+	var (
+		tpl                 = crd.Spec.PodTemplate
+		startCmd, startArgs = startCmdAndArgs(crd)
+		probes              = podReadinessProbes(crd)
+	)
 
 	pod := corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -76,27 +79,12 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 					// The following is a useful hack if you need to inspect the PV.
 					//Command: []string{"/bin/sh"},
 					//Args:    []string{"-c", `trap : TERM INT; sleep infinity & wait`},
-					Command:   []string{startCmd},
-					Args:      startArgs,
-					Env:       envVars,
-					Ports:     buildPorts(crd.Spec.Type),
-					Resources: tpl.Resources,
-					// TODO: temporary
-					//ReadinessProbe: &corev1.Probe{
-					//ProbeHandler: corev1.ProbeHandler{
-					//	HTTPGet: &corev1.HTTPGetAction{
-					//		Path:   "/health",
-					//		Port:   intstr.FromInt(rpcPort),
-					//		Scheme: corev1.URISchemeHTTP,
-					//	},
-					//},
-					//InitialDelaySeconds: 1,
-					//TimeoutSeconds:      10,
-					//PeriodSeconds:       10,
-					//SuccessThreshold:    1,
-					//FailureThreshold:    5,
-					//},
-
+					Command:         []string{startCmd},
+					Args:            startArgs,
+					Env:             envVars,
+					Ports:           buildPorts(crd.Spec.Type),
+					Resources:       tpl.Resources,
+					ReadinessProbe:  probes[0],
 					ImagePullPolicy: tpl.ImagePullPolicy,
 					WorkingDir:      workDir,
 				},
@@ -112,21 +100,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 							corev1.ResourceMemory: resource.MustParse("16Mi"),
 						},
 					},
-					// TODO: temporary
-					//	ReadinessProbe: nil, &corev1.Probe{
-					//		ProbeHandler: corev1.ProbeHandler{
-					//			HTTPGet: &corev1.HTTPGetAction{
-					//				Path:   "/",
-					//				Port:   intstr.FromInt(healthCheckPort),
-					//				Scheme: corev1.URISchemeHTTP,
-					//			},
-					//		},
-					//		InitialDelaySeconds: 1,
-					//		TimeoutSeconds:      10,
-					//		PeriodSeconds:       10,
-					//		SuccessThreshold:    1,
-					//		FailureThreshold:    3,
-					//	},
+					ReadinessProbe:  probes[1],
 					ImagePullPolicy: tpl.ImagePullPolicy,
 				},
 			},
@@ -140,6 +114,44 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 		crd: crd,
 		pod: &pod,
 	}
+}
+
+func podReadinessProbes(crd *cosmosv1.CosmosFullNode) []*corev1.Probe {
+	if crd.Spec.Type == cosmosv1.FullNodeSentry {
+		return []*corev1.Probe{nil, nil}
+	}
+
+	mainProbe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/health",
+				Port:   intstr.FromInt(rpcPort),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+		InitialDelaySeconds: 1,
+		TimeoutSeconds:      10,
+		PeriodSeconds:       10,
+		SuccessThreshold:    1,
+		FailureThreshold:    5,
+	}
+
+	sidecarProbe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/",
+				Port:   intstr.FromInt(healthCheckPort),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+		InitialDelaySeconds: 1,
+		TimeoutSeconds:      10,
+		PeriodSeconds:       10,
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+
+	return []*corev1.Probe{mainProbe, sidecarProbe}
 }
 
 // Attempts to produce a deterministic hash based on the pod template, so we can detect updates.

--- a/controllers/internal/fullnode/pod_builder.go
+++ b/controllers/internal/fullnode/pod_builder.go
@@ -77,25 +77,25 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 					// The following is a useful hack if you need to inspect the PV.
 					//Command: []string{"/bin/sh"},
 					//Args:    []string{"-c", `trap : TERM INT; sleep infinity & wait`},
-					Command:   []string{startCmd},
-					Args:      startArgs,
-					Env:       envVars,
-					Ports:     buildPorts(crd.Spec.Type),
-					Resources: tpl.Resources,
-					ReadinessProbe: &corev1.Probe{
-						ProbeHandler: corev1.ProbeHandler{
-							HTTPGet: &corev1.HTTPGetAction{
-								Path:   "/health",
-								Port:   intstr.FromInt(rpcPort),
-								Scheme: corev1.URISchemeHTTP,
-							},
-						},
-						InitialDelaySeconds: 1,
-						TimeoutSeconds:      10,
-						PeriodSeconds:       10,
-						SuccessThreshold:    1,
-						FailureThreshold:    5,
-					},
+					Command:        []string{startCmd},
+					Args:           startArgs,
+					Env:            envVars,
+					Ports:          buildPorts(crd.Spec.Type),
+					Resources:      tpl.Resources,
+					ReadinessProbe: nil, // &corev1.Probe{ TODO: temporary
+					//ProbeHandler: corev1.ProbeHandler{
+					//	HTTPGet: &corev1.HTTPGetAction{
+					//		Path:   "/health",
+					//		Port:   intstr.FromInt(rpcPort),
+					//		Scheme: corev1.URISchemeHTTP,
+					//	},
+					//},
+					//InitialDelaySeconds: 1,
+					//TimeoutSeconds:      10,
+					//PeriodSeconds:       10,
+					//SuccessThreshold:    1,
+					//FailureThreshold:    5,
+					//},
 
 					ImagePullPolicy: tpl.ImagePullPolicy,
 					WorkingDir:      workDir,

--- a/controllers/internal/fullnode/pod_builder.go
+++ b/controllers/internal/fullnode/pod_builder.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var bufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
@@ -77,12 +76,13 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 					// The following is a useful hack if you need to inspect the PV.
 					//Command: []string{"/bin/sh"},
 					//Args:    []string{"-c", `trap : TERM INT; sleep infinity & wait`},
-					Command:        []string{startCmd},
-					Args:           startArgs,
-					Env:            envVars,
-					Ports:          buildPorts(crd.Spec.Type),
-					Resources:      tpl.Resources,
-					ReadinessProbe: nil, // &corev1.Probe{ TODO: temporary
+					Command:   []string{startCmd},
+					Args:      startArgs,
+					Env:       envVars,
+					Ports:     buildPorts(crd.Spec.Type),
+					Resources: tpl.Resources,
+					// TODO: temporary
+					//ReadinessProbe: &corev1.Probe{
 					//ProbeHandler: corev1.ProbeHandler{
 					//	HTTPGet: &corev1.HTTPGetAction{
 					//		Path:   "/health",
@@ -112,20 +112,21 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 							corev1.ResourceMemory: resource.MustParse("16Mi"),
 						},
 					},
-					ReadinessProbe: &corev1.Probe{
-						ProbeHandler: corev1.ProbeHandler{
-							HTTPGet: &corev1.HTTPGetAction{
-								Path:   "/",
-								Port:   intstr.FromInt(healthCheckPort),
-								Scheme: corev1.URISchemeHTTP,
-							},
-						},
-						InitialDelaySeconds: 1,
-						TimeoutSeconds:      10,
-						PeriodSeconds:       10,
-						SuccessThreshold:    1,
-						FailureThreshold:    3,
-					},
+					// TODO: temporary
+					//	ReadinessProbe: nil, &corev1.Probe{
+					//		ProbeHandler: corev1.ProbeHandler{
+					//			HTTPGet: &corev1.HTTPGetAction{
+					//				Path:   "/",
+					//				Port:   intstr.FromInt(healthCheckPort),
+					//				Scheme: corev1.URISchemeHTTP,
+					//			},
+					//		},
+					//		InitialDelaySeconds: 1,
+					//		TimeoutSeconds:      10,
+					//		PeriodSeconds:       10,
+					//		SuccessThreshold:    1,
+					//		FailureThreshold:    3,
+					//	},
 					ImagePullPolicy: tpl.ImagePullPolicy,
 				},
 			},


### PR DESCRIPTION
Validator sentries do not serve traffic like RPC nodes. (Or at least, they shouldn't for safety.) An outsider should not be able to query or transact with a sentry. Only p2p is exposed.  K8s readiness probes are for serving traffic, which isn't a use case for sentries.

In our case, with horcrux and remote signers, we have a chicken or egg problem. Tendermint requires immediate connection to the remote signer. However, the chain process will not be ready until that connection is made.

We use k8s services for a stable IP for horcrux. Therefore, we cannot use readiness probes for sentries because k8s will never add the pod to the service. 