### PR TITLE
fix: Don't index by default for sentries

### DIFF
--- a/controllers/internal/fullnode/configmap_builder.go
+++ b/controllers/internal/fullnode/configmap_builder.go
@@ -113,6 +113,8 @@ func addConfigToml(buf *bytes.Buffer, cmData map[string]string, crd *cosmosv1.Co
 
 	if crd.Spec.Type == cosmosv1.FullNodeSentry {
 		base["priv_validator_laddr"] = fmt.Sprintf("tcp://0.0.0.0:%d", privvalPort)
+		// Disable indexing for sentries; they should not serve queries.
+		base["tx_index"] = map[string]string{"indexer": "null"}
 	}
 	if v := spec.LogLevel; v != nil {
 		base["log_level"] = v

--- a/controllers/internal/fullnode/configmap_builder.go
+++ b/controllers/internal/fullnode/configmap_builder.go
@@ -37,7 +37,7 @@ func BuildConfigMaps(crd *cosmosv1.CosmosFullNode, p2p ExternalAddresses) ([]*co
 	for i := int32(0); i < crd.Spec.Replicas; i++ {
 		data := make(map[string]string)
 		instance := instanceName(crd, i)
-		if err := addTendermintToml(buf, data, crd, p2p[instance]); err != nil {
+		if err := addConfigToml(buf, data, crd, p2p[instance]); err != nil {
 			return nil, err
 		}
 		buf.Reset()
@@ -105,7 +105,7 @@ func defaultApp() decodedToml {
 	return data
 }
 
-func addTendermintToml(buf *bytes.Buffer, cmData map[string]string, crd *cosmosv1.CosmosFullNode, externalAddress string) error {
+func addConfigToml(buf *bytes.Buffer, cmData map[string]string, crd *cosmosv1.CosmosFullNode, externalAddress string) error {
 	var (
 		spec = crd.Spec.ChainSpec
 		base = make(decodedToml)

--- a/controllers/internal/fullnode/configmap_builder_test.go
+++ b/controllers/internal/fullnode/configmap_builder_test.go
@@ -157,6 +157,7 @@ func TestBuildConfigMaps(t *testing.T) {
 			require.NotEmpty(t, got)
 
 			require.Equal(t, "tcp://0.0.0.0:1234", got["priv_validator_laddr"])
+			require.Equal(t, "null", got["tx_index"].(map[string]any)["indexer"])
 		})
 
 		t.Run("overrides", func(t *testing.T) {


### PR DESCRIPTION
Sets this default in `config.toml`.

```toml
[tx_index]
indexer = "null"
```

An oversight (because the Sentry feature was a bit rushed to meet a deadline).

Don't need to index on sentries which shouldn't be exposed to the internet for queries. 

Fyi, the user can always override these default values. 