### PR TITLE
fix(ScheduledSnapshotController): Confirm pod restoration before advancing

### DIFF
--- a/controllers/internal/volsnapshot/fullnode_control.go
+++ b/controllers/internal/volsnapshot/fullnode_control.go
@@ -61,10 +61,21 @@ func (control FullNodeControl) SignalPodRestoration(ctx context.Context, crd *co
 	return control.statusClient.Patch(ctx, &fn, raw)
 }
 
-func (control FullNodeControl) sourceKey(crd *cosmosalpha.ScheduledVolumeSnapshot) string {
-	key := strings.Join([]string{crd.Namespace, crd.Name, cosmosalpha.GroupVersion.Version, cosmosalpha.GroupVersion.Group}, ".")
-	// Remove all slashes because key is used in JSONPatch where slash "/" is a reserved character.
-	return strings.ReplaceAll(key, "/", "")
+// ConfirmPodRestoration verifies the pod has been restored.
+func (control FullNodeControl) ConfirmPodRestoration(ctx context.Context, crd *cosmosalpha.ScheduledVolumeSnapshot) error {
+	var pods corev1.PodList
+	if err := control.listClient.List(ctx, &pods,
+		client.InNamespace(crd.Spec.FullNodeRef.Namespace),
+		client.MatchingFields{kube.ControllerOwnerField: crd.Spec.FullNodeRef.Name},
+	); err != nil {
+		return fmt.Errorf("list pods: %w", err)
+	}
+	for _, pod := range pods.Items {
+		if pod.Name == crd.Status.Candidate.PodName {
+			return nil
+		}
+	}
+	return fmt.Errorf("pod %s not restored yet", crd.Status.Candidate.PodName)
 }
 
 // ConfirmPodDeletion returns a nil error if the pod is deleted.
@@ -84,4 +95,10 @@ func (control FullNodeControl) ConfirmPodDeletion(ctx context.Context, crd *cosm
 		}
 	}
 	return nil
+}
+
+func (control FullNodeControl) sourceKey(crd *cosmosalpha.ScheduledVolumeSnapshot) string {
+	key := strings.Join([]string{crd.Namespace, crd.Name, cosmosalpha.GroupVersion.Version, cosmosalpha.GroupVersion.Group}, ".")
+	// Remove all slashes because key is used in JSONPatch where slash "/" is a reserved character.
+	return strings.ReplaceAll(key, "/", "")
 }


### PR DESCRIPTION
Even though we delete appropriate data from the `fullNodeRef` status object AND check for the error, we've seen instances where the fullnode's status contains stale data. i.e. status data was never deleted. Therefore, the pod stays deleted even though the ScheduledSnapshotController expects it to be present. 

I'm unsure of the root cause. I've yet to catch it in the act. I'm hoping this confirmation step solves this bug. The controller will continually retry restoring the pod until it's able to find it in a list query. 