### PR TITLE
feat(CosmosFullNode): Use native health check for probes

### DIFF
--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -90,9 +90,10 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 				},
 				// Healtcheck sidecar to ensure pod is in sync with the chain.
 				{
-					Name:    "healthcheck",
-					Image:   "ghcr.io/strangelove-ventures/ignite-health-check:v0.0.1",
-					Command: []string{"ihc"},
+					Name: "healthcheck",
+					// Available images: https://github.com/orgs/strangelove-ventures/packages?repo_name=cosmos-operator
+					Image:   "ghcr.io/strangelove-ventures/cosmos-operator:v0.6.2",
+					Command: []string{"manager", "healtcheck"},
 					Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -93,7 +93,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 					Name: "healthcheck",
 					// Available images: https://github.com/orgs/strangelove-ventures/packages?repo_name=cosmos-operator
 					Image:   "ghcr.io/strangelove-ventures/cosmos-operator:v0.6.2",
-					Command: []string{"/manager", "healtcheck"},
+					Command: []string{"/manager", "healthcheck"},
 					Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -92,6 +92,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 				{
 					Name: "healthcheck",
 					// Available images: https://github.com/orgs/strangelove-ventures/packages?repo_name=cosmos-operator
+					// IMPORTANT: Must use v0.6.2 or later.
 					Image:   "ghcr.io/strangelove-ventures/cosmos-operator:v0.6.2",
 					Command: []string{"/manager", "healthcheck"},
 					Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -93,7 +93,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 					Name: "healthcheck",
 					// Available images: https://github.com/orgs/strangelove-ventures/packages?repo_name=cosmos-operator
 					Image:   "ghcr.io/strangelove-ventures/cosmos-operator:v0.6.2",
-					Command: []string{"manager", "healtcheck"},
+					Command: []string{"/manager", "healtcheck"},
 					Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{

--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -228,8 +228,8 @@ func TestPodBuilder(t *testing.T) {
 
 		healthContainer := pod.Spec.Containers[1]
 		require.Equal(t, "healthcheck", healthContainer.Name)
-		require.Equal(t, "ghcr.io/strangelove-ventures/ignite-health-check:v0.0.1", healthContainer.Image)
-		require.Equal(t, []string{"ihc"}, healthContainer.Command)
+		require.Equal(t, "ghcr.io/strangelove-ventures/cosmos-operator:v0.6.2", healthContainer.Image)
+		require.Equal(t, []string{"/manager", "healthcheck"}, healthContainer.Command)
 		require.Empty(t, healthContainer.Args)
 		require.Empty(t, healthContainer.ImagePullPolicy)
 		require.NotEmpty(t, healthContainer.Resources)

--- a/internal/healthcheck/healtcheck.go
+++ b/internal/healthcheck/healtcheck.go
@@ -1,3 +1,7 @@
+// Package healthcheck typically enables readiness or liveness probes within kubernetes.
+// IMPORTANT: If you update this behavior, be sure to update internal/fullnode/pod_builder.go with the new
+// cosmos operator image in the "healthcheck" container.
+//
 //nolint:misspell
 package healthcheck
 


### PR DESCRIPTION
Closes https://github.com/strangelove-ventures/cosmos-operator/issues/185

Deprecates and removes the ignite-health-check 3rd party container. 