### PR TITLE
fix(ScheduledVolumeSnapshot): Restore pod edge case

### DIFF
--- a/controllers/scheduledvolumesnapshot_controller.go
+++ b/controllers/scheduledvolumesnapshot_controller.go
@@ -167,7 +167,6 @@ func (r *ScheduledVolumeSnapshotReconciler) Reconcile(ctx context.Context, req c
 		// Order of operations important here. SignalPodRestoration fails if the fullnode's status is already updated.
 		if err := r.fullNodeControl.ConfirmPodRestoration(ctx, crd); err != nil {
 			logger.Info("Pod not restored; signaling fullnode to restore pod", "error", err)
-			r.recorder.Event(crd, eventNormal, "RestorePod", "Signaling fullnode to restore pod")
 			if err = r.fullNodeControl.SignalPodRestoration(ctx, crd); err != nil {
 				logger.Error(err, "Failed to update fullnode status for restoring pod")
 				r.reportError(crd, "RestorePodError", err)

--- a/internal/volsnapshot/fullnode_control_test.go
+++ b/internal/volsnapshot/fullnode_control_test.go
@@ -60,7 +60,9 @@ func (m mockReader) List(ctx context.Context, list client.ObjectList, opts ...cl
 
 var nopReader = mockReader{
 	Lister: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error { return nil },
-	Getter: func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error { return nil },
+	Getter: func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+		return nil
+	},
 }
 
 func TestFullNodeControl_SignalPodDeletion(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/strangelove-ventures/cosmos-operator/issues/196

After some "shower thinking", this is the better solution. To check the fullnode's status vs. its actual pods. This way, if fullnode has been scaled down, the ScheduledVolumeSnapshot still progresses. It only cares about that status being set correctly. 