### PR TITLE
fix(CosmosFullNode): Healthcheck disk stats directory

### DIFF
--- a/healtcheck_cmd.go
+++ b/healtcheck_cmd.go
@@ -50,7 +50,7 @@ func startHealthCheckServer(cmd *cobra.Command, args []string) error {
 
 	var (
 		tm   = healthcheck.NewTendermint(logger, tmClient, rpcHost, timeout)
-		disk = healthcheck.DiskUsage("/")
+		disk = healthcheck.DiskUsage("/home/operator/cosmos") // TODO: experimenting
 	)
 	router := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch path.Clean(r.URL.Path) {

--- a/healtcheck_cmd.go
+++ b/healtcheck_cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/strangelove-ventures/cosmos-operator/internal/cosmos"
+	"github.com/strangelove-ventures/cosmos-operator/internal/fullnode"
 	"github.com/strangelove-ventures/cosmos-operator/internal/healthcheck"
 	"golang.org/x/sync/errgroup"
 )
@@ -50,7 +51,7 @@ func startHealthCheckServer(cmd *cobra.Command, args []string) error {
 
 	var (
 		tm   = healthcheck.NewTendermint(logger, tmClient, rpcHost, timeout)
-		disk = healthcheck.DiskUsage("/home/operator/cosmos") // TODO: experimenting
+		disk = healthcheck.DiskUsage(fullnode.ChainHomeDir)
 	)
 	router := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch path.Clean(r.URL.Path) {

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -98,7 +98,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 			Name: "healthcheck",
 			// Available images: https://github.com/orgs/strangelove-ventures/packages?repo_name=cosmos-operator
 			// IMPORTANT: Must use v0.6.2 or later.
-			Image:   "ghcr.io/strangelove-ventures/cosmos-operator:v0.7.0",
+			Image:   "ghcr.io/strangelove-ventures/cosmos-operator:dev76d8c07-dirty", // TODO: use actual tag
 			Command: []string{"/manager", "healthcheck"},
 			Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},
 			Resources: corev1.ResourceRequirements{

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -98,7 +98,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 			Name: "healthcheck",
 			// Available images: https://github.com/orgs/strangelove-ventures/packages?repo_name=cosmos-operator
 			// IMPORTANT: Must use v0.6.2 or later.
-			Image:   "ghcr.io/strangelove-ventures/cosmos-operator:dev76d8c07-dirty", // TODO: use actual tag
+			Image:   "ghcr.io/strangelove-ventures/cosmos-operator:v0.7.0",
 			Command: []string{"/manager", "healthcheck"},
 			Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},
 			Resources: corev1.ResourceRequirements{

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -222,7 +222,7 @@ func (b PodBuilder) WithOrdinal(ordinal int32) PodBuilder {
 	}
 
 	mounts := []corev1.VolumeMount{
-		{Name: volChainHome, MountPath: chainHomeDir},
+		{Name: volChainHome, MountPath: ChainHomeDir},
 	}
 	for i := range pod.Spec.InitContainers {
 		pod.Spec.InitContainers[i].VolumeMounts = append(mounts, []corev1.VolumeMount{
@@ -239,21 +239,22 @@ func (b PodBuilder) WithOrdinal(ordinal int32) PodBuilder {
 }
 
 const (
-	workDir      = "/home/operator"
-	chainHomeDir = workDir + "/cosmos"
-	tmpDir       = workDir + "/.tmp"
-	tmpConfigDir = workDir + "/.config"
+	workDir = "/home/operator"
+	// ChainHomeDir is the abs filepath for the chain's home directory.
+	ChainHomeDir = workDir + "/cosmos"
 
+	tmpDir         = workDir + "/.tmp"
+	tmpConfigDir   = workDir + "/.config"
 	infraToolImage = "ghcr.io/strangelove-ventures/infra-toolkit:v0.0.1"
 )
 
 var (
 	envVars = []corev1.EnvVar{
 		{Name: "HOME", Value: workDir},
-		{Name: "CHAIN_HOME", Value: chainHomeDir},
-		{Name: "GENESIS_FILE", Value: path.Join(chainHomeDir, "config", "genesis.json")},
-		{Name: "CONFIG_DIR", Value: path.Join(chainHomeDir, "config")},
-		{Name: "DATA_DIR", Value: path.Join(chainHomeDir, "data")},
+		{Name: "CHAIN_HOME", Value: ChainHomeDir},
+		{Name: "GENESIS_FILE", Value: path.Join(ChainHomeDir, "config", "genesis.json")},
+		{Name: "CONFIG_DIR", Value: path.Join(ChainHomeDir, "config")},
+		{Name: "DATA_DIR", Value: path.Join(ChainHomeDir, "data")},
 	}
 )
 
@@ -357,7 +358,7 @@ func startCmdAndArgs(crd *cosmosv1.CosmosFullNode) (string, []string) {
 }
 
 func startCommandArgs(cfg cosmosv1.ChainSpec) []string {
-	args := []string{"start", "--home", chainHomeDir}
+	args := []string{"start", "--home", ChainHomeDir}
 	if cfg.SkipInvariants {
 		args = append(args, "--x-crisis-skip-assert-invariants")
 	}

--- a/internal/healthcheck/disk_usage_test.go
+++ b/internal/healthcheck/disk_usage_test.go
@@ -23,20 +23,32 @@ func TestDiskUsage(t *testing.T) {
 		err := json.Unmarshal(w.Body.Bytes(), &got)
 		require.NoError(t, err)
 
+		require.Equal(t, "/", got.Dir)
 		require.NotZero(t, got.AllBytes)
 		require.NotZero(t, got.FreeBytes)
 		require.True(t, got.AllBytes >= got.FreeBytes, "free bytes should not be more than all bytes")
+
+		require.NotContains(t, w.Body.String(), "error")
 	})
 
 	t.Run("statfs error", func(t *testing.T) {
+		const dir = "/this-directory-had-better-not-be-present-in-any-sort-of-test-environment\""
 		var (
 			w       = httptest.NewRecorder()
 			r       = httptest.NewRequest("GET", "/ignored", nil)
-			handler = DiskUsage("/this-directory-had-better-not-be-present-in-any-sort-of-test-environment")
+			handler = DiskUsage(dir)
 		)
 		handler(w, r)
 
 		require.Equal(t, 500, w.Code)
-		require.JSONEq(t, `{"error":"no such file or directory"}`, w.Body.String())
+
+		var got DiskUsageResponse
+		err := json.Unmarshal(w.Body.Bytes(), &got)
+		require.NoError(t, err)
+
+		require.Equal(t, dir, got.Dir)
+		require.Equal(t, "no such file or directory", got.Error)
+		require.NotContains(t, w.Body.String(), "all_bytes")
+		require.NotContains(t, w.Body.String(), "free_bytes")
 	})
 }


### PR DESCRIPTION
Supports https://github.com/strangelove-ventures/cosmos-operator/issues/18

We have to explicitly ask for stats on the PVC mount path to get accurate stats. Manual testing surfaced this bug. 

Given PVC capacity 500 Gi (note, the power of 2 unit, Gibibytes), the endpoint returns:

```sh
{"all_bytes":527295578112,"free_bytes":330858098688}
```

The `all_bytes` is equal to 491 Gi (Gibibytes). So it's close enough.

Using the root path `"/"` was giving total space of ~100G which is the ephemeral disk on the node.

The used spaced `all_bytes - free_bytes` percentage also matches with `df` in the container.

```
df
# Results (units are KB, not bytes)
Filesystem           1K-blocks      Used Available Use% Mounted on
/dev/sdb             514937088 192650484 322270220  37% /home/operator
```

From the healtcheck endpoint `/disk`.
```
(all_bytes - free_bytes) / all_bytes = ~37%
```

This also adds the dir to the response for easier debugging. 