### PR TITLE
fix(CosmosFullNode): Requeue if updated pvc is not bound yet

### DIFF
--- a/internal/fullnode/pvc_control.go
+++ b/internal/fullnode/pvc_control.go
@@ -101,6 +101,7 @@ func (control PVCControl) Reconcile(ctx context.Context, reporter kube.Reporter,
 		found, ok := findMatchingResource(pvc, currentPVCs)
 		if ok && found.Status.Phase != corev1.ClaimBound {
 			reporter.Info("PVC cannot be updated yet because it is not bound", "pvc", pvc.Name, "phase", found.Status.Phase)
+			reporter.RecordInfo("PVCUpdate", fmt.Sprintf("PVC %s cannot be updated yet because it is not bound; retrying", pvc.Name))
 			requeue = true
 			continue
 		}

--- a/internal/fullnode/pvc_control_test.go
+++ b/internal/fullnode/pvc_control_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/strangelove-ventures/cosmos-operator/internal/test"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -34,6 +35,10 @@ func TestPVCControl_Reconcile(t *testing.T) {
 			var pvc corev1.PersistentVolumeClaim
 			pvc.Name = fmt.Sprintf("pvc-%d", i)
 			pvc.Namespace = namespace
+			pvc.Spec.Resources = corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("100G")},
+			}
+			pvc.Status.Phase = corev1.ClaimBound
 			return &pvc
 		})
 	}
@@ -192,15 +197,11 @@ func TestPVCControl_Reconcile(t *testing.T) {
 
 	t.Run("updates", func(t *testing.T) {
 		updates := buildPVCs(2)
-		unbound := updates[0]
-		unbound.Status.Phase = corev1.ClaimPending
+		updatedResources := updates[0].Spec.Resources
 
-		var mClient mockPVCClient
-		mClient.ObjectList = corev1.PersistentVolumeClaimList{
-			Items: []corev1.PersistentVolumeClaim{*unbound},
-		}
 		var (
-			mDiff = mockPVCDiffer{
+			mClient mockPVCClient
+			mDiff   = mockPVCDiffer{
 				StubUpdates: updates,
 			}
 			crd     = defaultCRD()
@@ -218,13 +219,49 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		require.Empty(t, mClient.CreateCount)
 		require.Empty(t, mClient.DeleteCount)
 
-		// Count of 1 because we skip patching unbound claims (results in kube API error).
-		require.Equal(t, 1, mClient.PatchCount)
+		require.Equal(t, 2, mClient.PatchCount)
 		require.Equal(t, client.Merge, mClient.LastPatch)
 
-		gotPVC := mClient.LastPatchObject.(*corev1.PersistentVolumeClaim)
-		require.Empty(t, gotPVC.Spec.VolumeMode)
-		require.Equal(t, updates[1].Spec.Resources, gotPVC.Spec.Resources)
+		gotPatch := mClient.LastPatchObject.(*corev1.PersistentVolumeClaim)
+		require.Equal(t, updates[1].Name, gotPatch.Name)
+		require.Equal(t, namespace, gotPatch.Namespace)
+		require.Empty(t, gotPatch.Spec.VolumeMode)
+		require.Equal(t, updatedResources, gotPatch.Spec.Resources)
+	})
+
+	t.Run("updates with unbound volumes", func(t *testing.T) {
+		updates := buildPVCs(2)
+		unbound := updates[1]
+		unbound.Status.Phase = corev1.ClaimPending
+
+		var mClient mockPVCClient
+		mClient.ObjectList = corev1.PersistentVolumeClaimList{
+			Items: []corev1.PersistentVolumeClaim{*unbound},
+		}
+		var (
+			mDiff = mockPVCDiffer{
+				StubUpdates: updates,
+			}
+			crd     = defaultCRD()
+			control = testPVCControl(&mClient)
+		)
+		crd.Namespace = namespace
+		crd.Spec.VolumeClaimTemplate.Resources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Ti")},
+		}
+		control.diffFactory = func(_, _ string, current, want []*corev1.PersistentVolumeClaim) pvcDiffer {
+			return mDiff
+		}
+		requeue, rerr := control.Reconcile(ctx, nopReporter, &crd)
+		require.NoError(t, rerr)
+		require.True(t, requeue)
+
+		// Count of 1 because we skip patching unbound claims (results in kube API error).
+		require.Equal(t, 1, mClient.PatchCount)
+
+		gotPatch := mClient.LastPatchObject.(*corev1.PersistentVolumeClaim)
+		require.Equal(t, updates[0].Name, gotPatch.Name)
+		require.Equal(t, namespace, gotPatch.Namespace)
 	})
 
 	t.Run("retention policy", func(t *testing.T) {


### PR DESCRIPTION
Fixes an edge case. If you created then quickly resized the PVC, the resize may have been missed by the controller. 

Manually tested in a test cluster. 