### PR TITLE
paired with andrew to rework genesis check

### DIFF
--- a/internal/fullnode/genesis.go
+++ b/internal/fullnode/genesis.go
@@ -14,8 +14,10 @@ var (
 	scriptUseInitGenesis string
 )
 
-const genesisScriptWrapper = `if [ -f "$GENESIS_FILE" ]; then
-	echo "Genesis file $GENESIS_FILE already exists; skipping initialization."
+const genesisScriptWrapper = `ls $DATA_DIR/*.db 1> /dev/null 2>&1
+DB_INIT=$?
+if [ $DB_INIT -eq 0 ]; then
+	echo "Database already initialized, skipping genesis initialization"
 	exit 0
 fi
 

--- a/internal/fullnode/genesis_test.go
+++ b/internal/fullnode/genesis_test.go
@@ -13,7 +13,7 @@ func TestDownloadGenesisCommand(t *testing.T) {
 	requireValidScript := func(t *testing.T, script string) {
 		t.Helper()
 		require.NotEmpty(t, script)
-		require.Contains(t, script, `if [ -f "$GENESIS_FILE" ]`)
+		require.Contains(t, script, `if [ $DB_INIT -eq 0 ]`)
 	}
 
 	t.Run("default", func(t *testing.T) {

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -275,8 +275,6 @@ set -eu
 if [ ! -d "$CHAIN_HOME/data" ]; then
 	echo "Initializing chain..."
 	%s --home "$CHAIN_HOME"
-	# Remove because downstream containers check the presence of this file.
-	rm "$GENESIS_FILE"
 else
 	echo "Skipping chain init; already initialized."
 fi


### PR DESCRIPTION
The genesis check was failing on noble.  It was giving an error saying `rm` not found.  @agouin and I reworked it to follow the genesis check we used in the infra in the past.