### PR TITLE
refactor(CosmosFullNode): Revert genesis init flow to original

### DIFF
--- a/internal/fullnode/genesis.go
+++ b/internal/fullnode/genesis.go
@@ -14,10 +14,8 @@ var (
 	scriptUseInitGenesis string
 )
 
-const genesisScriptWrapper = `ls $DATA_DIR/*.db 1> /dev/null 2>&1
-DB_INIT=$?
-if [ $DB_INIT -eq 0 ]; then
-	echo "Database already initialized, skipping genesis initialization"
+const genesisScriptWrapper = `if [ -f "$GENESIS_FILE" ]; then
+	echo "Genesis file $GENESIS_FILE already exists; skipping initialization."
 	exit 0
 fi
 

--- a/internal/fullnode/genesis_test.go
+++ b/internal/fullnode/genesis_test.go
@@ -13,7 +13,7 @@ func TestDownloadGenesisCommand(t *testing.T) {
 	requireValidScript := func(t *testing.T, script string) {
 		t.Helper()
 		require.NotEmpty(t, script)
-		require.Contains(t, script, `if [ $DB_INIT -eq 0 ]`)
+		require.Contains(t, script, `if [ -f "$GENESIS_FILE" ]`)
 	}
 
 	t.Run("default", func(t *testing.T) {


### PR DESCRIPTION
The reasoning is here: https://github.com/strangelove-ventures/cosmos-operator/pull/216/files/4279bb89e3432802e35578f15f597474a93f5c63#r1118912461

In the referenced PR, it wasn't clear to me if this code change was fixing an issue. To me, I think it has no bearing. But if I'm mistaken and it IS fixing something, please let's discuss.

Edit:

You know what, it may be because we are no longer removing the genesis file. So it's always present. Therefore, checking the for `*.db` is what we have to use for now. 