### PR TITLE
Build docker images on pull requests for further integration tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - '**'
+  pull_request:
+    
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Following the standard set in https://github.com/strangelove-ventures/horcrux/blob/main/.github/workflows/docker-publish.yaml

This will allow docker images to be build on pull requests. This will be the first in a phase of enhancements that look to run regression tests, and report back directly in the PR to ensure code enhancements are not breaking any functionality tested in the test suite.

*Currently in draft to test functionality on pull requests / Will require maintainer approval before new workflows can run*