### PR TITLE
refactor(CosmosFullNode): Restore healtcheck sidecar container

### DIFF
--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -92,25 +92,23 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 		},
 	}
 
-	if crd.Spec.PodTemplate.Probes.Strategy != cosmosv1.FullNodeProbeStrategyNone {
-		// Healtcheck sidecar to ensure pod is in sync with the chain.
-		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
-			Name: "healthcheck",
-			// Available images: https://github.com/orgs/strangelove-ventures/packages?repo_name=cosmos-operator
-			// IMPORTANT: Must use v0.6.2 or later.
-			Image:   "ghcr.io/strangelove-ventures/cosmos-operator:v0.7.0",
-			Command: []string{"/manager", "healthcheck"},
-			Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("5m"),
-					corev1.ResourceMemory: resource.MustParse("16Mi"),
-				},
+	// Add healtcheck sidecar
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+		Name: "healthcheck",
+		// Available images: https://github.com/orgs/strangelove-ventures/packages?repo_name=cosmos-operator
+		// IMPORTANT: Must use v0.6.2 or later.
+		Image:   "ghcr.io/strangelove-ventures/cosmos-operator:v0.7.0",
+		Command: []string{"/manager", "healthcheck"},
+		Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("5m"),
+				corev1.ResourceMemory: resource.MustParse("16Mi"),
 			},
-			ReadinessProbe:  probes[1],
-			ImagePullPolicy: tpl.ImagePullPolicy,
-		})
-	}
+		},
+		ReadinessProbe:  probes[1],
+		ImagePullPolicy: tpl.ImagePullPolicy,
+	})
 
 	preserveMergeInto(pod.Labels, tpl.Metadata.Labels)
 	preserveMergeInto(pod.Annotations, tpl.Metadata.Annotations)

--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -440,8 +440,12 @@ gaiad start --home /home/operator/cosmos`
 			require.Nilf(t, cont.ReadinessProbe, "container %d", i)
 		}
 
-		require.Equal(t, 1, len(pod.Spec.Containers))
+		require.Equal(t, 2, len(pod.Spec.Containers))
 		require.Equal(t, "node", pod.Spec.Containers[0].Name)
+
+		sidecar := pod.Spec.Containers[1]
+		require.Equal(t, "healthcheck", sidecar.Name)
+		require.Nil(t, sidecar.ReadinessProbe)
 	})
 }
 


### PR DESCRIPTION
Supports https://github.com/strangelove-ventures/cosmos-operator/issues/18

In the future, the operator will make requests to pods over the healthcheck port. Therefore, we require the sidecar to always be present. Originally removed because sentries do not have probes. 

The sidecar will not have probes (as unit tests prove).