### PR TITLE
feat(CosmosFullNode): SelfHealing collects disk percentages

### DIFF
--- a/controllers/cosmosfullnode_controller.go
+++ b/controllers/cosmosfullnode_controller.go
@@ -53,7 +53,7 @@ type CosmosFullNodeReconciler struct {
 // NewFullNode returns a valid CosmosFullNode controller.
 func NewFullNode(client client.Client, recorder record.EventRecorder) *CosmosFullNodeReconciler {
 	var (
-		podFilter = cosmos.NewPodFilter(cosmos.NewTendermintClient(tendermintHTTP))
+		podFilter = cosmos.NewPodFilter(cosmos.NewTendermintClient(sharedHTTPClient))
 	)
 	return &CosmosFullNodeReconciler{
 		Client:           client,

--- a/controllers/scheduledvolumesnapshot_controller.go
+++ b/controllers/scheduledvolumesnapshot_controller.go
@@ -41,13 +41,13 @@ type ScheduledVolumeSnapshotReconciler struct {
 	volSnapshotControl *volsnapshot.VolumeSnapshotControl
 }
 
-var tendermintHTTP = &http.Client{Timeout: 60 * time.Second}
+var sharedHTTPClient = &http.Client{Timeout: 60 * time.Second}
 
 func NewScheduledVolumeSnapshotReconciler(
 	client client.Client,
 	recorder record.EventRecorder,
 ) *ScheduledVolumeSnapshotReconciler {
-	tmClient := cosmos.NewTendermintClient(tendermintHTTP)
+	tmClient := cosmos.NewTendermintClient(sharedHTTPClient)
 	return &ScheduledVolumeSnapshotReconciler{
 		Client:             client,
 		fullNodeControl:    volsnapshot.NewFullNodeControl(client.Status(), client),

--- a/controllers/selfhealing_controller.go
+++ b/controllers/selfhealing_controller.go
@@ -75,7 +75,7 @@ func (r *SelfHealingReconciler) pvcAutoScale(ctx context.Context, logger logr.Lo
 		return
 	}
 	// TODO: temporary to prove incremental phases of pvc auto scaling
-	results, err := fullnode.CollectPodDiskUsage(ctx, crd, r, r.diskClient)
+	results, err := fullnode.CollectDiskUsage(ctx, crd, r, r.diskClient)
 	if err != nil {
 		logger.Error(err, "Failed to collect pod disk usage")
 		return

--- a/controllers/selfhealing_controller.go
+++ b/controllers/selfhealing_controller.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 Strangelove Ventures LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// SelfHealingReconciler reconciles the self healing portion of a CosmosFullNode object
+type SelfHealingReconciler struct {
+	client.Client
+	recorder record.EventRecorder
+}
+
+func NewSelfHealing(client client.Client, recorder record.EventRecorder) *SelfHealingReconciler {
+	return &SelfHealingReconciler{
+		Client:   client,
+		recorder: recorder,
+	}
+}
+
+// Reconcile reconciles only the self-healing spec in CosmosFullNode. If changes needed, this controller
+// updates a CosmosFullNode status subresource thus triggering another reconcile loop. The CosmosFullNode
+// uses the status object to reconcile its state.
+func (r *SelfHealingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Entering reconcile loop", "request", req.NamespacedName)
+
+	crd := new(cosmosv1.CosmosFullNode)
+	if err := r.Get(ctx, req.NamespacedName, crd); err != nil {
+		// Ignore not found errors because can't be fixed by an immediate requeue. We'll have to wait for next notification.
+		// Also, will get "not found" error if crd is deleted.
+		// No need to explicitly delete resources. Kube GC does so automatically because we set the controller reference
+		// for each resource.
+		return finishResult, client.IgnoreNotFound(err)
+	}
+
+	if crd.Spec.SelfHealing == nil {
+		return finishResult, nil
+	}
+
+	return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+}
+
+func (r *SelfHealingReconciler) pvcAutoScale(ctx context.Context, crd *cosmosv1.CosmosFullNode) {
+	if crd.Spec.SelfHealing.PVCAutoScaling == nil {
+		return
+	}
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SelfHealingReconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager) error {
+	// We do not have to index Pods because the CosmosFullNodeReconciler already does so.
+	// If we repeat it here, the manager returns an error.
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&cosmosv1.CosmosFullNode{}).
+		Complete(r)
+}

--- a/healtcheck_cmd.go
+++ b/healtcheck_cmd.go
@@ -27,7 +27,7 @@ func healthcheckCmd() *cobra.Command {
 	hc.Flags().String("rpc-host", "http://localhost:26657", "tendermint rpc endpoint")
 	hc.Flags().String("log-format", "console", "'console' or 'json'")
 	hc.Flags().Duration("timeout", 5*time.Second, "how long to wait before timing out requests to rpc-host")
-	hc.Flags().String("addr", fmt.Sprintf(":%d", fullnode.HealthCheckPort), "listen address for server to bind")
+	hc.Flags().String("addr", fmt.Sprintf(":%d", healthcheck.Port), "listen address for server to bind")
 
 	if err := viper.BindPFlags(hc.Flags()); err != nil {
 		panic(err)

--- a/internal/fullnode/client.go
+++ b/internal/fullnode/client.go
@@ -1,0 +1,12 @@
+package fullnode
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Lister can list resources, subset of client.Client.
+type Lister interface {
+	List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
+}

--- a/internal/fullnode/mock_test.go
+++ b/internal/fullnode/mock_test.go
@@ -17,6 +17,7 @@ type mockClient[T client.Object] struct {
 
 	ObjectList  any
 	GotListOpts []client.ListOption
+	ListErr     error
 
 	CreateCount      int
 	LastCreateObject T
@@ -73,7 +74,7 @@ func (m *mockClient[T]) List(ctx context.Context, list client.ObjectList, opts .
 		panic(fmt.Errorf("unknown ObjectList type: %T", m.ObjectList))
 	}
 
-	return nil
+	return m.ListErr
 }
 
 func (m *mockClient[T]) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {

--- a/internal/fullnode/p2p.go
+++ b/internal/fullnode/p2p.go
@@ -13,11 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Lister can list resources, subset of client.Client.
-type Lister interface {
-	List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
-}
-
 // ExternalAddresses keys are instance names and values are public IPs or hostnames.
 type ExternalAddresses map[string]string
 

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -98,7 +98,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 		Name: "healthcheck",
 		// Available images: https://github.com/orgs/strangelove-ventures/packages?repo_name=cosmos-operator
 		// IMPORTANT: Must use v0.6.2 or later.
-		Image:   "ghcr.io/strangelove-ventures/cosmos-operator:v0.7.0",
+		Image:   "ghcr.io/strangelove-ventures/cosmos-operator:v0.9.2",
 		Command: []string{"/manager", "healthcheck"},
 		Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},
 		Resources: corev1.ResourceRequirements{

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
+	"github.com/strangelove-ventures/cosmos-operator/internal/healthcheck"
 	"github.com/strangelove-ventures/cosmos-operator/internal/kube"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -20,8 +21,7 @@ import (
 
 var bufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
 
-// HealthCheckPort is the port for the healtcheck sidecar.
-const HealthCheckPort = 1251
+const healthCheckPort = healthcheck.Port
 
 // PodBuilder builds corev1.Pods
 type PodBuilder struct {
@@ -100,7 +100,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 		// IMPORTANT: Must use v0.6.2 or later.
 		Image:   "ghcr.io/strangelove-ventures/cosmos-operator:v0.7.0",
 		Command: []string{"/manager", "healthcheck"},
-		Ports:   []corev1.ContainerPort{{ContainerPort: HealthCheckPort, Protocol: corev1.ProtocolTCP}},
+		Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("5m"),
@@ -144,7 +144,7 @@ func podReadinessProbes(crd *cosmosv1.CosmosFullNode) []*corev1.Probe {
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path:   "/",
-				Port:   intstr.FromInt(HealthCheckPort),
+				Port:   intstr.FromInt(healthCheckPort),
 				Scheme: corev1.URISchemeHTTP,
 			},
 		},

--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -228,7 +228,7 @@ func TestPodBuilder(t *testing.T) {
 
 		healthContainer := pod.Spec.Containers[1]
 		require.Equal(t, "healthcheck", healthContainer.Name)
-		require.Equal(t, "ghcr.io/strangelove-ventures/cosmos-operator:v0.7.0", healthContainer.Image)
+		require.Equal(t, "ghcr.io/strangelove-ventures/cosmos-operator:v0.9.2", healthContainer.Image)
 		require.Equal(t, []string{"/manager", "healthcheck"}, healthContainer.Command)
 		require.Empty(t, healthContainer.Args)
 		require.Empty(t, healthContainer.ImagePullPolicy)

--- a/internal/fullnode/pod_disk_usage.go
+++ b/internal/fullnode/pod_disk_usage.go
@@ -26,11 +26,11 @@ type PodDiskUsage struct {
 	PercentUsed int
 }
 
-// FindPodsDiskUsage retrieves the disk usage information for all Pods belonging to the specified CosmosFullNode.
+// CollectPodDiskUsage retrieves the disk usage information for all Pods belonging to the specified CosmosFullNode.
 //
 // It returns a slice of PodDiskUsage objects representing the disk usage information for each Pod or an error
 // if fetching disk usage from all pods was unsuccessful.
-func FindPodsDiskUsage(ctx context.Context, crd *cosmosv1.CosmosFullNode, lister Lister, diskClient DiskUsager) ([]PodDiskUsage, error) {
+func CollectPodDiskUsage(ctx context.Context, crd *cosmosv1.CosmosFullNode, lister Lister, diskClient DiskUsager) ([]PodDiskUsage, error) {
 	var pods corev1.PodList
 	if err := lister.List(ctx, &pods,
 		client.InNamespace(crd.Namespace),

--- a/internal/fullnode/pod_disk_usage.go
+++ b/internal/fullnode/pod_disk_usage.go
@@ -1,0 +1,79 @@
+package fullnode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/samber/lo"
+	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
+	"github.com/strangelove-ventures/cosmos-operator/internal/healthcheck"
+	"github.com/strangelove-ventures/cosmos-operator/internal/kube"
+	"go.uber.org/multierr"
+	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DiskUsager fetches disk usage statistics
+type DiskUsager interface {
+	DiskUsage(ctx context.Context, host string) (healthcheck.DiskUsageResponse, error)
+}
+
+type PodDiskUsage struct {
+	Name        string // pod name
+	PercentUsed int
+}
+
+// FindPodsDiskUsage retrieves the disk usage information for all Pods belonging to the specified CosmosFullNode.
+//
+// It returns a slice of PodDiskUsage objects representing the disk usage information for each Pod or an error
+// if fetching disk usage from all pods was unsuccessful.
+func FindPodsDiskUsage(ctx context.Context, crd *cosmosv1.CosmosFullNode, lister Lister, diskClient DiskUsager) ([]PodDiskUsage, error) {
+	var pods corev1.PodList
+	if err := lister.List(ctx, &pods,
+		client.InNamespace(crd.Namespace),
+		client.MatchingFields{kube.ControllerOwnerField: crd.Name},
+	); err != nil {
+		return nil, fmt.Errorf("list pods: %w", err)
+	}
+
+	if len(pods.Items) == 0 {
+		return nil, errors.New("no pods found")
+	}
+
+	var (
+		found = make([]PodDiskUsage, len(pods.Items))
+		errs  = make([]error, len(pods.Items))
+		eg    errgroup.Group
+	)
+
+	for i := range pods.Items {
+		i := i
+		eg.Go(func() error {
+			pod := pods.Items[i]
+			cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			resp, err := diskClient.DiskUsage(cctx, "http://"+pod.Status.PodIP)
+			if err != nil {
+				errs[i] = fmt.Errorf("pod %s: %w", pod.Name, err)
+				return nil
+			}
+			found[i].Name = pod.Name
+			found[i].PercentUsed = int((float64(resp.AllBytes-resp.FreeBytes) / float64(resp.AllBytes)) * 100)
+			return nil
+		})
+	}
+
+	_ = eg.Wait()
+
+	errs = lo.Filter(errs, func(item error, _ int) bool {
+		return item != nil
+	})
+	if len(errs) == len(pods.Items) {
+		return nil, multierr.Combine(errs...)
+	}
+
+	return lo.Compact(found), nil
+}

--- a/internal/fullnode/pod_disk_usage_test.go
+++ b/internal/fullnode/pod_disk_usage_test.go
@@ -21,7 +21,7 @@ func (fn mockDiskUsager) DiskUsage(ctx context.Context, host string) (healthchec
 	return fn(ctx, host)
 }
 
-func TestFindPodsDiskUsage(t *testing.T) {
+func TestCollectPodDiskUsage(t *testing.T) {
 	t.Parallel()
 
 	type mockLister = mockClient[*corev1.Pod]
@@ -58,7 +58,7 @@ func TestFindPodsDiskUsage(t *testing.T) {
 		crd.Name = "cosmoshub"
 		crd.Namespace = "default"
 
-		got, err := FindPodsDiskUsage(ctx, &crd, &lister, diskClient)
+		got, err := CollectPodDiskUsage(ctx, &crd, &lister, diskClient)
 
 		require.NoError(t, err)
 		require.Len(t, got, 3)
@@ -96,7 +96,7 @@ func TestFindPodsDiskUsage(t *testing.T) {
 		})
 
 		var crd cosmosv1.CosmosFullNode
-		_, err := FindPodsDiskUsage(ctx, &crd, &lister, diskClient)
+		_, err := CollectPodDiskUsage(ctx, &crd, &lister, diskClient)
 
 		require.Error(t, err)
 		require.EqualError(t, err, "no pods found")
@@ -113,7 +113,7 @@ func TestFindPodsDiskUsage(t *testing.T) {
 		})
 
 		var crd cosmosv1.CosmosFullNode
-		_, err := FindPodsDiskUsage(ctx, &crd, &lister, diskClient)
+		_, err := CollectPodDiskUsage(ctx, &crd, &lister, diskClient)
 
 		require.Error(t, err)
 		require.EqualError(t, err, "list pods: boom")
@@ -138,7 +138,7 @@ func TestFindPodsDiskUsage(t *testing.T) {
 
 		var crd cosmosv1.CosmosFullNode
 
-		got, err := FindPodsDiskUsage(ctx, &crd, &lister, diskClient)
+		got, err := CollectPodDiskUsage(ctx, &crd, &lister, diskClient)
 
 		require.NoError(t, err)
 		require.Len(t, got, 1)
@@ -159,7 +159,7 @@ func TestFindPodsDiskUsage(t *testing.T) {
 
 		var crd cosmosv1.CosmosFullNode
 
-		_, err := FindPodsDiskUsage(ctx, &crd, &lister, diskClient)
+		_, err := CollectPodDiskUsage(ctx, &crd, &lister, diskClient)
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "pod 1: boom")

--- a/internal/fullnode/pod_disk_usage_test.go
+++ b/internal/fullnode/pod_disk_usage_test.go
@@ -46,7 +46,7 @@ func TestCollectDiskUsage(t *testing.T) {
 			case "http://10.0.0.3":
 				free = 15 // Tests rounding up
 			default:
-				panic(fmt.Errorf("unkonwn host: %s", host))
+				panic(fmt.Errorf("unkown host: %s", host))
 			}
 			return healthcheck.DiskUsageResponse{
 				AllBytes:  1000,

--- a/internal/fullnode/pod_disk_usage_test.go
+++ b/internal/fullnode/pod_disk_usage_test.go
@@ -46,7 +46,7 @@ func TestCollectDiskUsage(t *testing.T) {
 			case "http://10.0.0.3":
 				free = 15 // Tests rounding up
 			default:
-				panic(fmt.Errorf("unkown host: %s", host))
+				panic(fmt.Errorf("unknown host: %s", host))
 			}
 			return healthcheck.DiskUsageResponse{
 				AllBytes:  1000,

--- a/internal/fullnode/pod_disk_usage_test.go
+++ b/internal/fullnode/pod_disk_usage_test.go
@@ -49,7 +49,7 @@ func TestCollectPodDiskUsage(t *testing.T) {
 				panic(fmt.Errorf("unkonwn host: %s", host))
 			}
 			return healthcheck.DiskUsageResponse{
-				AllBytes:  100,
+				AllBytes:  101, // Odd number tests truncating
 				FreeBytes: free,
 			}, nil
 		})

--- a/internal/fullnode/pod_disk_usage_test.go
+++ b/internal/fullnode/pod_disk_usage_test.go
@@ -1,0 +1,168 @@
+package fullnode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+
+	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
+	"github.com/strangelove-ventures/cosmos-operator/internal/healthcheck"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type mockDiskUsager func(ctx context.Context, host string) (healthcheck.DiskUsageResponse, error)
+
+func (fn mockDiskUsager) DiskUsage(ctx context.Context, host string) (healthcheck.DiskUsageResponse, error) {
+	return fn(ctx, host)
+}
+
+func TestFindPodsDiskUsage(t *testing.T) {
+	t.Parallel()
+
+	type mockLister = mockClient[*corev1.Pod]
+
+	ctx := context.Background()
+
+	t.Run("happy path", func(t *testing.T) {
+		var lister mockLister
+		lister.ObjectList = corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}, Status: corev1.PodStatus{PodIP: "10.0.0.1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}, Status: corev1.PodStatus{PodIP: "10.0.0.2"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "pod-3"}, Status: corev1.PodStatus{PodIP: "10.0.0.3"}},
+		}}
+
+		diskClient := mockDiskUsager(func(ctx context.Context, host string) (healthcheck.DiskUsageResponse, error) {
+			var free uint64
+			switch host {
+			case "http://10.0.0.1":
+				free = 90
+			case "http://10.0.0.2":
+				free = 50
+			case "http://10.0.0.3":
+				free = 10
+			default:
+				panic(fmt.Errorf("unkonwn host: %s", host))
+			}
+			return healthcheck.DiskUsageResponse{
+				AllBytes:  100,
+				FreeBytes: free,
+			}, nil
+		})
+
+		var crd cosmosv1.CosmosFullNode
+		crd.Name = "cosmoshub"
+		crd.Namespace = "default"
+
+		got, err := FindPodsDiskUsage(ctx, &crd, &lister, diskClient)
+
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+
+		require.Len(t, lister.GotListOpts, 2)
+		var listOpt client.ListOptions
+		for _, opt := range lister.GotListOpts {
+			opt.ApplyToList(&listOpt)
+		}
+		require.Equal(t, "default", listOpt.Namespace)
+		require.Zero(t, listOpt.Limit)
+		require.Equal(t, ".metadata.controller=cosmoshub", listOpt.FieldSelector.String())
+
+		sort.Slice(got, func(i, j int) bool {
+			return got[i].Name < got[j].Name
+		})
+
+		result := got[0]
+		require.Equal(t, "pod-1", result.Name)
+		require.Equal(t, 10, result.PercentUsed)
+
+		result = got[1]
+		require.Equal(t, "pod-2", result.Name)
+		require.Equal(t, 50, result.PercentUsed)
+
+		result = got[2]
+		require.Equal(t, "pod-3", result.Name)
+		require.Equal(t, 90, result.PercentUsed)
+	})
+
+	t.Run("no pods found", func(t *testing.T) {
+		var lister mockLister
+		diskClient := mockDiskUsager(func(ctx context.Context, host string) (healthcheck.DiskUsageResponse, error) {
+			panic("should not be called")
+		})
+
+		var crd cosmosv1.CosmosFullNode
+		_, err := FindPodsDiskUsage(ctx, &crd, &lister, diskClient)
+
+		require.Error(t, err)
+		require.EqualError(t, err, "no pods found")
+	})
+
+	t.Run("list error", func(t *testing.T) {
+		var lister mockLister
+		lister.ObjectList = corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}, Status: corev1.PodStatus{PodIP: "10.0.0.1"}},
+		}}
+		lister.ListErr = errors.New("boom")
+		diskClient := mockDiskUsager(func(ctx context.Context, host string) (healthcheck.DiskUsageResponse, error) {
+			panic("should not be called")
+		})
+
+		var crd cosmosv1.CosmosFullNode
+		_, err := FindPodsDiskUsage(ctx, &crd, &lister, diskClient)
+
+		require.Error(t, err)
+		require.EqualError(t, err, "list pods: boom")
+	})
+
+	t.Run("partial disk client errors", func(t *testing.T) {
+		var lister mockLister
+		lister.ObjectList = corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}, Status: corev1.PodStatus{PodIP: "10.0.0.1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "pod-2"}, Status: corev1.PodStatus{PodIP: "10.0.0.2"}},
+		}}
+
+		diskClient := mockDiskUsager(func(ctx context.Context, host string) (healthcheck.DiskUsageResponse, error) {
+			if host == "http://10.0.0.1" {
+				return healthcheck.DiskUsageResponse{}, errors.New("boom")
+			}
+			return healthcheck.DiskUsageResponse{
+				AllBytes:  100,
+				FreeBytes: 100,
+			}, nil
+		})
+
+		var crd cosmosv1.CosmosFullNode
+
+		got, err := FindPodsDiskUsage(ctx, &crd, &lister, diskClient)
+
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+
+		require.Equal(t, "pod-2", got[0].Name)
+	})
+
+	t.Run("disk client error", func(t *testing.T) {
+		var lister mockLister
+		lister.ObjectList = corev1.PodList{Items: []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{Name: "1"}, Status: corev1.PodStatus{PodIP: "10.0.0.1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "2"}, Status: corev1.PodStatus{PodIP: "10.0.0.2"}},
+		}}
+
+		diskClient := mockDiskUsager(func(ctx context.Context, host string) (healthcheck.DiskUsageResponse, error) {
+			return healthcheck.DiskUsageResponse{}, errors.New("boom")
+		})
+
+		var crd cosmosv1.CosmosFullNode
+
+		_, err := FindPodsDiskUsage(ctx, &crd, &lister, diskClient)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "pod 1: boom")
+		require.Contains(t, err.Error(), "pod 2: boom")
+	})
+}

--- a/internal/healthcheck/client.go
+++ b/internal/healthcheck/client.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-
-	"github.com/strangelove-ventures/cosmos-operator/internal/fullnode"
 )
 
 // Client can be used to query healthcheck information.
@@ -18,7 +16,7 @@ type Client struct {
 
 func NewClient(client *http.Client) *Client {
 	return &Client{
-		rootURL: fmt.Sprintf("http://localhost:%d", fullnode.HealthCheckPort),
+		rootURL: fmt.Sprintf("http://localhost:%d", Port),
 		httpDo:  client.Do,
 	}
 }

--- a/internal/healthcheck/client.go
+++ b/internal/healthcheck/client.go
@@ -5,26 +5,35 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
+	"strconv"
 )
 
 // Client can be used to query healthcheck information.
 type Client struct {
-	rootURL string
-	httpDo  func(req *http.Request) (*http.Response, error)
+	httpDo func(req *http.Request) (*http.Response, error)
 }
 
 func NewClient(client *http.Client) *Client {
 	return &Client{
-		rootURL: fmt.Sprintf("http://localhost:%d", Port),
-		httpDo:  client.Do,
+		httpDo: client.Do,
 	}
 }
 
 // DiskUsage returns disk usage statistics or an error if unable to obtain.
-func (c Client) DiskUsage(ctx context.Context) (DiskUsageResponse, error) {
+// Do not include the port in the host.
+func (c Client) DiskUsage(ctx context.Context, host string) (DiskUsageResponse, error) {
 	var diskResp DiskUsageResponse
-	req, err := http.NewRequestWithContext(ctx, "GET", c.rootURL+"/disk", nil)
+	u, err := url.Parse(host)
+	if err != nil {
+		return diskResp, fmt.Errorf("url parse: %w", err)
+	}
+	u.Host = net.JoinHostPort(u.Host, strconv.Itoa(Port))
+	u.Path = "/disk"
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
 		return diskResp, fmt.Errorf("new request: %w", err)
 	}

--- a/internal/healthcheck/client.go
+++ b/internal/healthcheck/client.go
@@ -48,5 +48,8 @@ func (c Client) DiskUsage(ctx context.Context, host string) (DiskUsageResponse, 
 	if diskResp.Error != "" {
 		return diskResp, errors.New(diskResp.Error)
 	}
+	if diskResp.AllBytes == 0 {
+		return diskResp, errors.New("invalid response: 0 free bytes")
+	}
 	return diskResp, nil
 }

--- a/internal/healthcheck/client_test.go
+++ b/internal/healthcheck/client_test.go
@@ -19,6 +19,8 @@ func TestClient_DiskUsage(t *testing.T) {
 		httpClient = &http.Client{}
 	)
 
+	const host = "http://10.1.1.1"
+
 	t.Run("happy path", func(t *testing.T) {
 		client := NewClient(httpClient)
 		require.NotNil(t, client.httpDo)
@@ -30,7 +32,7 @@ func TestClient_DiskUsage(t *testing.T) {
 		}
 
 		client.httpDo = func(req *http.Request) (*http.Response, error) {
-			require.Equal(t, "http://localhost:1251/disk", req.URL.String())
+			require.Equal(t, "http://10.1.1.1:1251/disk", req.URL.String())
 			require.Equal(t, "GET", req.Method)
 
 			b, err := json.Marshal(want)
@@ -40,7 +42,7 @@ func TestClient_DiskUsage(t *testing.T) {
 			return &http.Response{Body: io.NopCloser(bytes.NewReader(b))}, nil
 		}
 
-		got, err := client.DiskUsage(ctx)
+		got, err := client.DiskUsage(ctx, host)
 
 		require.NoError(t, err)
 		require.Equal(t, want, got)
@@ -51,7 +53,7 @@ func TestClient_DiskUsage(t *testing.T) {
 		client.httpDo = func(req *http.Request) (*http.Response, error) {
 			return nil, errors.New("boom")
 		}
-		_, err := client.DiskUsage(ctx)
+		_, err := client.DiskUsage(ctx, host)
 
 		require.Error(t, err)
 		require.EqualError(t, err, "http do: boom")
@@ -71,7 +73,7 @@ func TestClient_DiskUsage(t *testing.T) {
 			}, nil
 		}
 
-		_, err := client.DiskUsage(ctx)
+		_, err := client.DiskUsage(ctx, host)
 
 		require.Error(t, err)
 		require.EqualError(t, err, "something bad happened")
@@ -86,7 +88,7 @@ func TestClient_DiskUsage(t *testing.T) {
 			}, nil
 		}
 
-		_, err := client.DiskUsage(ctx)
+		_, err := client.DiskUsage(ctx, host)
 
 		require.Error(t, err)
 		require.EqualError(t, err, "malformed json: unexpected EOF")

--- a/internal/healthcheck/client_test.go
+++ b/internal/healthcheck/client_test.go
@@ -93,4 +93,19 @@ func TestClient_DiskUsage(t *testing.T) {
 		require.Error(t, err)
 		require.EqualError(t, err, "malformed json: unexpected EOF")
 	})
+
+	t.Run("zero values", func(t *testing.T) {
+		client := NewClient(httpClient)
+
+		client.httpDo = func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body: io.NopCloser(strings.NewReader(`{}`)),
+			}, nil
+		}
+
+		_, err := client.DiskUsage(ctx, host)
+
+		require.Error(t, err)
+		require.EqualError(t, err, "invalid response: 0 free bytes")
+	})
 }

--- a/internal/healthcheck/healtchcheck.go
+++ b/internal/healthcheck/healtchcheck.go
@@ -1,0 +1,4 @@
+package healthcheck
+
+// Port is the port for the healthcheck sidecar.
+const Port = 1251

--- a/main.go
+++ b/main.go
@@ -167,6 +167,13 @@ func startManager(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to create CosmosFullNode controller: %w", err)
 	}
 
+	if err = controllers.NewSelfHealing(
+		mgr.GetClient(),
+		mgr.GetEventRecorderFor("CosmosFullNode"),
+	).SetupWithManager(ctx, mgr); err != nil {
+		return fmt.Errorf("unable to create SelfHealing controller: %w", err)
+	}
+
 	if err = controllers.NewStatefulJob(
 		mgr.GetClient(),
 		mgr.GetEventRecorderFor("StatefulJob"),

--- a/main.go
+++ b/main.go
@@ -169,7 +169,7 @@ func startManager(cmd *cobra.Command, args []string) error {
 
 	if err = controllers.NewSelfHealing(
 		mgr.GetClient(),
-		mgr.GetEventRecorderFor("CosmosFullNode"),
+		mgr.GetEventRecorderFor("SelfHealing"),
 	).SetupWithManager(ctx, mgr); err != nil {
 		return fmt.Errorf("unable to create SelfHealing controller: %w", err)
 	}


### PR DESCRIPTION
Phase 2 of https://github.com/strangelove-ventures/cosmos-operator/issues/18

Introduces the SelfHealingReconciler which also watches a CosmosFullNode. 

Additionally:
* Uses upgraded healtcheck image for the sidecar so we get the `/disk` endpoint.
* Checks for invalid disk usage responses of 0 free bytes (which causes a divide by 0)
* Collects disk usage for all PVCs. 
* Rounds disk usage to nearest integer (instead of truncating)

Temporarily logs disk usage, such as:

```
manager 2023-03-08T18:18:04Z    info    SelfHealing    Found pod disk usage    {"controller": "cosmosfullnode", "controllerGroup": "cosmos.strange.love", "controllerKind": "CosmosFullNode", "CosmosF
ullNode": {"name":"cosmoshub","namespace":"default"}, "namespace": "default", "name": "cosmoshub", "reconcileID": "179bf81a-4053-47c5-b7a9-d3dfccdcf82c", "results": [{"Name":"cosmoshub-1","PercentUs
ed":53},{"Name":"cosmoshub-0","PercentUsed":54}]}
```