### PR TITLE
feat(CosmosFullNode): PVC builder uses auto scale quantity

### DIFF
--- a/internal/fullnode/pvc_builder.go
+++ b/internal/fullnode/pvc_builder.go
@@ -85,6 +85,7 @@ func pvcName(crd *cosmosv1.CosmosFullNode, ordinal int32) string {
 func pvcRevisionHash(crd *cosmosv1.CosmosFullNode) string {
 	h := fnv.New32()
 	mustWrite(h, mustMarshalJSON(crd.Spec.VolumeClaimTemplate))
+	mustWrite(h, mustMarshalJSON(crd.Status.SelfHealing.PVCAutoScale))
 
 	keys := maps.Keys(crd.Spec.InstanceOverrides)
 	sort.Strings(keys)

--- a/internal/fullnode/pvc_builder.go
+++ b/internal/fullnode/pvc_builder.go
@@ -54,7 +54,7 @@ func BuildPVCs(crd *cosmosv1.CosmosFullNode) []*corev1.PersistentVolumeClaim {
 
 		pvc.Spec = corev1.PersistentVolumeClaimSpec{
 			AccessModes:      sliceOrDefault(tpl.AccessModes, defaultAccessModes),
-			Resources:        tpl.Resources,
+			Resources:        pvcResources(crd),
 			StorageClassName: ptr(tpl.StorageClassName),
 			VolumeMode:       valOrDefault(tpl.VolumeMode, ptr(corev1.PersistentVolumeFilesystem)),
 			DataSource:       tpl.DataSource,
@@ -78,6 +78,19 @@ func pvcDisabled(crd *cosmosv1.CosmosFullNode, ordinal int32) bool {
 func pvcName(crd *cosmosv1.CosmosFullNode, ordinal int32) string {
 	name := fmt.Sprintf("pvc-%s-%d", appName(crd), ordinal)
 	return kube.ToName(name)
+}
+
+func pvcResources(crd *cosmosv1.CosmosFullNode) corev1.ResourceRequirements {
+	var (
+		reqs = crd.Spec.VolumeClaimTemplate.Resources
+		size = reqs.Requests[corev1.ResourceStorage]
+	)
+	if autoScale := crd.Status.SelfHealing.PVCAutoScale; autoScale != nil {
+		if autoScale.RequestedSize.Cmp(size) > 0 {
+			reqs.Requests[corev1.ResourceStorage] = autoScale.RequestedSize
+		}
+	}
+	return reqs
 }
 
 // Attempts to produce a deterministic hash based on the pvc template, so we can detect updates.

--- a/internal/fullnode/pvc_builder_test.go
+++ b/internal/fullnode/pvc_builder_test.go
@@ -187,5 +187,9 @@ func FuzzBuildPVCs(f *testing.F) {
 
 		// Test determinism because maps are involved.
 		require.Equal(t, pvc4.Labels[kube.RevisionLabel], BuildPVCs(&crd)[0].Labels[kube.RevisionLabel])
+
+		crd.Status.SelfHealing.PVCAutoScale = &cosmosv1.PVCAutoScaleStatus{}
+		pvc5 := BuildPVCs(&crd)[0]
+		require.NotEqual(t, pvc4.Labels[kube.RevisionLabel], pvc5.Labels[kube.RevisionLabel])
 	})
 }


### PR DESCRIPTION
Closes https://github.com/strangelove-ventures/cosmos-operator/issues/18

When we build PVCs, we take the greater of storage set by the user or set by the pvc auto scaler. 