### PR TITLE
feat: Add init-fullnode subcommand stub

### DIFF
--- a/healtcheck_cmd.go
+++ b/healtcheck_cmd.go
@@ -18,8 +18,8 @@ import (
 
 func healthcheckCmd() *cobra.Command {
 	hc := &cobra.Command{
-		Short:        "Start health check probe",
 		Use:          "healthcheck",
+		Short:        "Start health check probe",
 		RunE:         startHealthCheckServer,
 		SilenceUsage: true,
 	}

--- a/init_fullnode_command.go
+++ b/init_fullnode_command.go
@@ -20,6 +20,7 @@ TODO:
 - Manage files created from the chain's init command.
 - Download genesis files.
 - Download and extract snapshots.
+- Merge toml files.
 `,
 		RunE:         initFullNode,
 		SilenceUsage: true,

--- a/init_fullnode_command.go
+++ b/init_fullnode_command.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"github.com/go-logr/zapr"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func initFullNodeCmd() *cobra.Command {
+	initFlow := &cobra.Command{
+		Use:   "init-fullnode",
+		Short: "Initialize a fullnode, prepping the environment for use by the chain process.",
+		Long: `Initialize a fullnode including creating, moving, downloading files necessary for a chain to run.
+Intended to run as an init container for a CosmosFullNode pod.
+
+****Currently this command is a stub.****
+
+TODO:
+- Check for legacy data locations and migrate to proper PVC path. A response to https://github.com/osmosis-labs/osmosis/issues/4654.
+- Manage files created from the chain's init command.
+- Download genesis files.
+- Download and extract snapshots.
+`,
+		RunE:         initFullNode,
+		SilenceUsage: true,
+	}
+
+	initFlow.Flags().String("log-format", "console", "'console' or 'json'")
+	initFlow.Flags().String("log-level", "info", "log level")
+
+	if err := viper.BindPFlags(initFlow.Flags()); err != nil {
+		panic(err)
+	}
+
+	return initFlow
+}
+
+func initFullNode(cmd *cobra.Command, args []string) error {
+	var (
+		zlog   = zapLogger(viper.GetString("log-level"), viper.GetString("log-format"))
+		logger = zapr.NewLogger(zlog)
+	)
+	defer func() { _ = zlog.Sync() }()
+
+	logger.Info("Command init-fullnode called, this command is currently a stub and does nothing.")
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -94,8 +94,8 @@ var (
 
 func rootCmd() *cobra.Command {
 	root := &cobra.Command{
-		Short:        "Run the operator",
 		Use:          "manager",
+		Short:        "Run the operator",
 		Version:      vcsRevision,
 		RunE:         startManager,
 		SilenceUsage: true,
@@ -116,6 +116,7 @@ func rootCmd() *cobra.Command {
 
 	// Add subcommands here
 	root.AddCommand(healthcheckCmd())
+	root.AddCommand(initFullNodeCmd())
 
 	return root
 }


### PR DESCRIPTION
Starts https://github.com/strangelove-ventures/cosmos-operator/issues/237

The thought here is an init container using this operator subcommand. Eventually, we can consolidate a lot of init container steps into a single container, use Go instead of bash, and have more functionality under tests.