### PR TITLE
feat: Add WaitingForP2PServices fullnode phase

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -113,6 +113,7 @@ type FullNodeStatus struct {
 	// The current phase of the fullnode deployment.
 	// "Progressing" means the deployment is under way.
 	// "Complete" means the deployment is complete and reconciliation is finished.
+	// "WaitingForP2PServices" means the deployment is complete but the p2p services are not yet ready.
 	// "Error" means an unrecoverable error occurred, which needs human intervention.
 	Phase FullNodePhase `json:"phase"`
 
@@ -144,6 +145,7 @@ const (
 	FullNodePhaseProgressing FullNodePhase = "Progressing"
 	FullNodePhaseCompete     FullNodePhase = "Complete"
 	FullNodePhaseError       FullNodePhase = "Error"
+	FullNodePhaseP2PServices FullNodePhase = "WaitingForP2PServices"
 )
 
 // Metadata is a subset of k8s object metadata.

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -1743,8 +1743,10 @@ spec:
               phase:
                 description: The current phase of the fullnode deployment. "Progressing"
                   means the deployment is under way. "Complete" means the deployment
-                  is complete and reconciliation is finished. "Error" means an unrecoverable
-                  error occurred, which needs human intervention.
+                  is complete and reconciliation is finished. "WaitingForP2PServices"
+                  means the deployment is complete but the p2p services are not yet
+                  ready. "Error" means an unrecoverable error occurred, which needs
+                  human intervention.
                 type: string
               scheduledSnapshotStatus:
                 additionalProperties:

--- a/controllers/cosmosfullnode_controller.go
+++ b/controllers/cosmosfullnode_controller.go
@@ -149,6 +149,7 @@ func (r *CosmosFullNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if p2pAddresses.Incomplete() {
 		reporter.Info("Requeueing due to incomplete p2p external addresses")
 		reporter.RecordInfo("P2PIncomplete", "Waiting for p2p service IPs or Hostnames to be ready.")
+		crd.Status.Phase = cosmosv1.FullNodePhaseP2PServices
 		// Allow more time to requeue while p2p services create their load balancers.
 		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 	}


### PR DESCRIPTION
Starts https://github.com/strangelove-ventures/cosmos-operator/issues/21

Adding more fine-grained phases allows the user to understand what's happening with the operator. 

For this story, it lets the user know p2p services are still being provisioned. Therefore, it lets the user know that they should not use the peer ids yet. 