### PR TITLE
refactor: Upgrade Go to 1.20

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.19.0'
+          go-version: '>=1.20.2'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -29,6 +29,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.19.0'
+          go-version: '>=1.20.2'
       - name: unit tests
         run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/strangelove-ventures/cosmos-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Go is on 1.20.2. Time to upgrade. Loosely part of https://github.com/strangelove-ventures/cosmos-operator/issues/21, so that we have the latest patches to crypto packages. 