### PR TITLE
fix: Don't rely on volume order when finding PVC name

### DIFF
--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -542,5 +542,10 @@ func TestPVCName(t *testing.T) {
 	builder := NewPodBuilder(&crd)
 	pod, err := builder.WithOrdinal(5).Build()
 	require.NoError(t, err)
+
+	require.Equal(t, "pvc-osmosis-5", PVCName(pod))
+
+	pod.Spec.Volumes = append([]corev1.Volume{{Name: "foo"}}, pod.Spec.Volumes...)
+
 	require.Equal(t, "pvc-osmosis-5", PVCName(pod))
 }


### PR DESCRIPTION
Addresses https://github.com/strangelove-ventures/cosmos-operator/issues/244, but does not solve it. We should still handle the error case if the VolumeSnapshot fails. 

We can now inject other volumes into pods. This means we cannot rely on the order of volumes when fetching the PVC name. 