### PR TITLE
fix(lint): Remove rand.Seed, use local source if available

### DIFF
--- a/internal/cosmos/pod_filter_test.go
+++ b/internal/cosmos/pod_filter_test.go
@@ -3,9 +3,7 @@ package cosmos
 import (
 	"context"
 	"errors"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
@@ -23,7 +21,6 @@ var nopLogger = logr.Discard()
 
 func TestPodFilter_SyncedPods(t *testing.T) {
 	t.Parallel()
-	rand.Seed(time.Now().UnixNano())
 
 	ctx := context.Background()
 

--- a/internal/fullnode/pvc_auto_scaler_test.go
+++ b/internal/fullnode/pvc_auto_scaler_test.go
@@ -25,7 +25,7 @@ func (fn mockStatusSyncer) SyncUpdate(ctx context.Context, key client.ObjectKey,
 
 func TestPVCAutoScaler_SignalPVCResize(t *testing.T) {
 	t.Parallel()
-	rand.Seed(time.Now().UnixNano())
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	ctx := context.Background()
 
@@ -89,7 +89,7 @@ func TestPVCAutoScaler_SignalPVCResize(t *testing.T) {
 				return stubNow
 			}
 
-			trigger := 80 + rand.Intn(20)
+			trigger := 80 + r.Intn(20)
 			usage := []PVCDiskUsage{
 				{PercentUsed: trigger, Capacity: capacity},
 				{PercentUsed: 10},

--- a/internal/kube/labels_test.go
+++ b/internal/kube/labels_test.go
@@ -71,8 +71,8 @@ func TestMustToInt(t *testing.T) {
 
 	require.EqualValues(t, 123, MustToInt(ToIntegerValue(123)))
 
-	rand.Seed(time.Now().UnixNano())
-	n := rand.Intn(1000)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	n := r.Intn(1000)
 	require.EqualValues(t, n, MustToInt(fmt.Sprintf("%d", n)))
 
 	for _, badValue := range []string{"", "1.2", "1-2"} {

--- a/internal/kube/volume_snapshot_test.go
+++ b/internal/kube/volume_snapshot_test.go
@@ -3,7 +3,6 @@ package kube
 import (
 	"context"
 	"errors"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -44,7 +43,6 @@ func (fn mockLister) List(ctx context.Context, list client.ObjectList, opts ...c
 
 func TestRecentVolumeSnapshot(t *testing.T) {
 	t.Parallel()
-	rand.Seed(time.Now().UnixNano())
 
 	var (
 		ctx      = context.Background()

--- a/internal/volsnapshot/vol_snapshot_control_test.go
+++ b/internal/volsnapshot/vol_snapshot_control_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"strconv"
 	"testing"
 	"time"
@@ -309,7 +308,6 @@ func (m *mockVolumeSnapshotClient) Delete(ctx context.Context, obj client.Object
 
 func TestVolumeSnapshotControl_DeleteOldSnapshots(t *testing.T) {
 	t.Parallel()
-	rand.Seed(time.Now().UnixNano())
 
 	ctx := context.Background()
 


### PR DESCRIPTION
`main` branch was failing CI lint stage. 

Per Go 1.20 documentation:

```
// Deprecated: Programs that call Seed and then expect a specific sequence
// of results from the global random source (using functions such as Int)
// can be broken when a dependency changes how much it consumes
// from the global random source. To avoid such breakages, programs
// that need a specific result sequence should use NewRand(NewSource(seed))
// to obtain a random generator that other packages cannot access.
```

## Known Issues

`lo.Shuffle` uses the global source. Only used for tests, so I left as-is. 

It's odd CI on PRs is not catching this...