### PR TITLE
feat(CosmosFullNode): Healthcheck sidecar uses build version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: VERSION=${{ steps.meta.outputs.tags }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,10 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY internal/ internal/
 
+ARG GIT_TAG
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X internal/version.gitTag=$GIT_TAG" -a -o manager .
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY internal/ internal/
 
-ARG GIT_TAG
+ARG VERSION
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X internal/version.gitTag=$GIT_TAG" -a -o manager .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/strangelove-ventures/cosmos-operator/internal/version.version=$VERSION" -a -o manager .
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,7 @@ build: generate ## Build manager binary.
 run: manifests generate ## Run a controller from your host.
 	go run . --log-level=debug
 
-GIT_TAG ?= $(shell git describe --always --dirty)
-PRE_IMG ?= ghcr.io/strangelove-ventures/cosmos-operator:dev$(GIT_TAG)
+PRE_IMG ?= ghcr.io/strangelove-ventures/cosmos-operator:dev$(shell git describe --always --dirty)
 .PHONY: docker-prerelease
 docker-prerelease: ## Build and push a prerelease docker image.
 	IMG=$(PRE_IMG) $(MAKE) docker-build docker-push
@@ -96,7 +95,7 @@ docker-prerelease: ## Build and push a prerelease docker image.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} --build-arg GIT_TAG=$(GIT_TAG) .
+	docker build -t ${IMG} --build-arg VERSION=$(shell echo ${IMG} | awk -F: '{print $$2}') .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,8 @@ build: generate ## Build manager binary.
 run: manifests generate ## Run a controller from your host.
 	go run . --log-level=debug
 
-PRE_IMG ?= ghcr.io/strangelove-ventures/cosmos-operator:dev$(shell git describe --always --dirty)
+GIT_TAG ?= $(shell git describe --always --dirty)
+PRE_IMG ?= ghcr.io/strangelove-ventures/cosmos-operator:dev$(GIT_TAG)
 .PHONY: docker-prerelease
 docker-prerelease: ## Build and push a prerelease docker image.
 	IMG=$(PRE_IMG) $(MAKE) docker-build docker-push
@@ -95,7 +96,7 @@ docker-prerelease: ## Build and push a prerelease docker image.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build -t ${IMG} --build-arg GIT_TAG=$(GIT_TAG) .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -92,7 +92,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 		Name: "healthcheck",
 		// Available images: https://github.com/orgs/strangelove-ventures/packages?repo_name=cosmos-operator
 		// IMPORTANT: Must use v0.6.2 or later.
-		Image:   "ghcr.io/strangelove-ventures/cosmos-operator:" + version.Get(),
+		Image:   "ghcr.io/strangelove-ventures/cosmos-operator:" + version.DockerTag(),
 		Command: []string{"/manager", "healthcheck"},
 		Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},
 		Resources: corev1.ResourceRequirements{

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -14,6 +14,7 @@ import (
 	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
 	"github.com/strangelove-ventures/cosmos-operator/internal/healthcheck"
 	"github.com/strangelove-ventures/cosmos-operator/internal/kube"
+	"github.com/strangelove-ventures/cosmos-operator/internal/version"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -91,7 +92,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 		Name: "healthcheck",
 		// Available images: https://github.com/orgs/strangelove-ventures/packages?repo_name=cosmos-operator
 		// IMPORTANT: Must use v0.6.2 or later.
-		Image:   "ghcr.io/strangelove-ventures/cosmos-operator:v0.9.2",
+		Image:   "ghcr.io/strangelove-ventures/cosmos-operator:" + version.Get(),
 		Command: []string{"/manager", "healthcheck"},
 		Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},
 		Resources: corev1.ResourceRequirements{

--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -230,7 +230,7 @@ func TestPodBuilder(t *testing.T) {
 
 		healthContainer := pod.Spec.Containers[1]
 		require.Equal(t, "healthcheck", healthContainer.Name)
-		require.Equal(t, "ghcr.io/strangelove-ventures/cosmos-operator:v0.9.2", healthContainer.Image)
+		require.Equal(t, "ghcr.io/strangelove-ventures/cosmos-operator:latest", healthContainer.Image)
 		require.Equal(t, []string{"/manager", "healthcheck"}, healthContainer.Command)
 		require.Empty(t, healthContainer.Args)
 		require.Empty(t, healthContainer.ImagePullPolicy)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,8 +6,8 @@ package version
 // See Dockerfile, Makefile, and .github/workflows/release.yaml.
 var version = ""
 
-// Get returns the version of the build or "latest" if the version is empty.
-func Get() string {
+// DockerTag returns the version of the build or "latest" if the version is empty.
+func DockerTag() string {
 	if version == "" {
 		return "latest"
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,14 @@
+package version
+
+// version is the version of the build.
+// Set via ldflags at build time.
+// See Dockerfile, Makefile, and .github/workflows/release.yaml.
+var version = ""
+
+// Get returns the version of the build or "latest" if the version is empty.
+func Get() string {
+	if version == "" {
+		return "latest"
+	}
+	return version
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,14 +1,15 @@
 package version
 
-// version is the version of the build.
+// gitTag is the gitTag of the build.
 // Set via ldflags at build time.
+// Used for docker image.
 // See Dockerfile, Makefile, and .github/workflows/release.yaml.
-var version = ""
+var gitTag = ""
 
-// Get returns the version of the build or "latest" if the version is empty.
+// Get returns the gitTag of the build or "latest" if the gitTag is empty.
 func Get() string {
-	if version == "" {
+	if gitTag == "" {
 		return "latest"
 	}
-	return version
+	return gitTag
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,15 +1,15 @@
 package version
 
-// gitTag is the gitTag of the build.
+// version is the version of the build.
 // Set via ldflags at build time.
 // Used for docker image.
 // See Dockerfile, Makefile, and .github/workflows/release.yaml.
-var gitTag = ""
+var version = ""
 
-// Get returns the gitTag of the build or "latest" if the gitTag is empty.
+// Get returns the version of the build or "latest" if the version is empty.
 func Get() string {
-	if gitTag == "" {
+	if version == "" {
 		return "latest"
 	}
-	return gitTag
+	return version
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,10 +6,18 @@ package version
 // See Dockerfile, Makefile, and .github/workflows/release.yaml.
 var version = ""
 
-// DockerTag returns the version of the build or "latest" if the version is empty.
+// DockerTag returns the version of the build or "latest" if unknown.
 func DockerTag() string {
 	if version == "" {
 		return "latest"
+	}
+	return version
+}
+
+// AppVersion returns the version of the build or "(devel)" if unknown.
+func AppVersion() string {
+	if version == "" {
+		return "(devel)"
 	}
 	return version
 }

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func rootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Short:        "Run the operator",
 		Use:          "manager",
-		Version:      version.DockerTag(),
+		Version:      version.AppVersion(),
 		RunE:         startManager,
 		SilenceUsage: true,
 	}
@@ -192,7 +192,7 @@ func startManager(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to set up ready check: %w", err)
 	}
 
-	setupLog.Info("Starting Cosmos Operator manager", "version", version.DockerTag())
+	setupLog.Info("Starting Cosmos Operator manager", "version", version.AppVersion())
 	if err := mgr.Start(ctx); err != nil {
 		return fmt.Errorf("problem running manager: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"runtime/debug"
 
 	"github.com/go-logr/zapr"
 	"github.com/pkg/profile"
@@ -28,6 +27,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/strangelove-ventures/cosmos-operator/controllers"
 	"github.com/strangelove-ventures/cosmos-operator/internal/fullnode"
+	"github.com/strangelove-ventures/cosmos-operator/internal/version"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -61,17 +61,6 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
-var vcsRevision = func() string {
-	if info, ok := debug.ReadBuildInfo(); ok {
-		for _, setting := range info.Settings {
-			if setting.Key == "vcs.revision" {
-				return setting.Value
-			}
-		}
-	}
-	return ""
-}()
-
 func main() {
 	root := rootCmd()
 
@@ -96,7 +85,7 @@ func rootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Short:        "Run the operator",
 		Use:          "manager",
-		Version:      vcsRevision,
+		Version:      version.Get(),
 		RunE:         startManager,
 		SilenceUsage: true,
 	}
@@ -203,7 +192,7 @@ func startManager(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to set up ready check: %w", err)
 	}
 
-	setupLog.Info("starting manager")
+	setupLog.Info("Starting Cosmos Operator manager", "version", version.Get())
 	if err := mgr.Start(ctx); err != nil {
 		return fmt.Errorf("problem running manager: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func rootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Short:        "Run the operator",
 		Use:          "manager",
-		Version:      version.Get(),
+		Version:      version.DockerTag(),
 		RunE:         startManager,
 		SilenceUsage: true,
 	}
@@ -192,7 +192,7 @@ func startManager(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to set up ready check: %w", err)
 	}
 
-	setupLog.Info("Starting Cosmos Operator manager", "version", version.Get())
+	setupLog.Info("Starting Cosmos Operator manager", "version", version.DockerTag())
 	if err := mgr.Start(ctx); err != nil {
 		return fmt.Errorf("problem running manager: %w", err)
 	}


### PR DESCRIPTION
The healthcheck sidecar now uses the version passed in via ldflags. 

This prevents manual steps of 1) releasing a new version 2) manually updating the tag in pod builder to that version and 3) releasing yet another version so the sidecar is up to date. 

## TODO

Need to make sure the release GH workflow works. I'll push a release candidate soon and debug if necessary. 