### PR TITLE
refactor(CosmosFullNode): PVCs use new diffing

### DIFF
--- a/internal/fullnode/pvc_builder.go
+++ b/internal/fullnode/pvc_builder.go
@@ -1,15 +1,11 @@
 package fullnode
 
 import (
-	"encoding/hex"
 	"fmt"
-	"hash/fnv"
-	"sort"
 
 	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
 	"github.com/strangelove-ventures/cosmos-operator/internal/diff"
 	"github.com/strangelove-ventures/cosmos-operator/internal/kube"
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -89,20 +85,4 @@ func pvcResources(crd *cosmosv1.CosmosFullNode) corev1.ResourceRequirements {
 		}
 	}
 	return reqs
-}
-
-// Attempts to produce a deterministic hash based on the pvc template, so we can detect updates.
-// See podRevisionHash for more details.
-func pvcRevisionHash(crd *cosmosv1.CosmosFullNode) string {
-	h := fnv.New32()
-	mustWrite(h, mustMarshalJSON(crd.Spec.VolumeClaimTemplate))
-	mustWrite(h, mustMarshalJSON(crd.Status.SelfHealing.PVCAutoScale))
-
-	keys := maps.Keys(crd.Spec.InstanceOverrides)
-	sort.Strings(keys)
-	for _, k := range keys {
-		mustWrite(h, mustMarshalJSON(crd.Spec.InstanceOverrides[k].VolumeClaimTemplate))
-	}
-
-	return hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/fullnode/pvc_builder_test.go
+++ b/internal/fullnode/pvc_builder_test.go
@@ -37,7 +37,9 @@ func TestBuildPVCs(t *testing.T) {
 			require.NotEmpty(t, r.Revision())
 		}
 
-		pvcs := lo.Map(BuildPVCs(&crd), func(r diff.Resource[*corev1.PersistentVolumeClaim], _ int) *corev1.PersistentVolumeClaim { return r.Object() })
+		pvcs := lo.Map(BuildPVCs(&crd), func(r diff.Resource[*corev1.PersistentVolumeClaim], _ int) *corev1.PersistentVolumeClaim {
+			return r.Object()
+		})
 
 		require.Len(t, pvcs, 3)
 

--- a/internal/fullnode/pvc_control.go
+++ b/internal/fullnode/pvc_control.go
@@ -38,7 +38,6 @@ func (control PVCControl) Reconcile(ctx context.Context, reporter kube.Reporter,
 	if err := control.client.List(ctx, &vols,
 		client.InNamespace(crd.Namespace),
 		client.MatchingFields{kube.ControllerOwnerField: crd.Name},
-		SelectorLabels(crd),
 	); err != nil {
 		return false, kube.TransientError(fmt.Errorf("list existing pvcs: %w", err))
 	}

--- a/internal/fullnode/pvc_control_test.go
+++ b/internal/fullnode/pvc_control_test.go
@@ -56,14 +56,13 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, requeue)
 
-		require.Len(t, mClient.GotListOpts, 3)
+		require.Len(t, mClient.GotListOpts, 2)
 		var listOpt client.ListOptions
 		for _, opt := range mClient.GotListOpts {
 			opt.ApplyToList(&listOpt)
 		}
 		require.Equal(t, namespace, listOpt.Namespace)
 		require.Zero(t, listOpt.Limit)
-		require.Equal(t, "app.kubernetes.io/name=hub", listOpt.LabelSelector.String())
 		require.Equal(t, ".metadata.controller=hub", listOpt.FieldSelector.String())
 	})
 


### PR DESCRIPTION
Moves PVC reconciliation to the new diff. The only one left after this is pods. 