### PR TITLE
feat(CosmosFullNode): Create p2p services for each pod

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -146,10 +146,11 @@ type FullNodeSnapshotStatus struct {
 type FullNodePhase string
 
 const (
-	FullNodePhaseProgressing FullNodePhase = "Progressing"
-	FullNodePhaseCompete     FullNodePhase = "Complete"
-	FullNodePhaseError       FullNodePhase = "Error"
-	FullNodePhaseP2PServices FullNodePhase = "WaitingForP2PServices"
+	FullNodePhaseCompete        FullNodePhase = "Complete"
+	FullNodePhaseError          FullNodePhase = "Error"
+	FullNodePhaseP2PServices    FullNodePhase = "WaitingForP2PServices"
+	FullNodePhaseProgressing    FullNodePhase = "Progressing"
+	FullNodePhaseTransientError FullNodePhase = "TransientError"
 )
 
 // Metadata is a subset of k8s object metadata.

--- a/controllers/cosmosfullnode_controller.go
+++ b/controllers/cosmosfullnode_controller.go
@@ -262,6 +262,18 @@ func (r *CosmosFullNodeReconciler) SetupWithManager(ctx context.Context, mgr ctr
 	if err != nil {
 		return fmt.Errorf("service index field %s: %w", controllerOwnerField, err)
 	}
+	err = mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&corev1.Service{},
+		".spec.type",
+		func(obj client.Object) []string {
+			svc := obj.(*corev1.Service)
+			return []string{string(svc.Spec.Type)}
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("service index field .spec.type: %w", err)
+	}
 
 	cbuilder := ctrl.NewControllerManagedBy(mgr).For(&cosmosv1.CosmosFullNode{})
 

--- a/controllers/cosmosfullnode_controller.go
+++ b/controllers/cosmosfullnode_controller.go
@@ -127,7 +127,7 @@ func (r *CosmosFullNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// Reconcile ConfigMaps.
-	p2pAddresses, err := fullnode.CollectP2PAddresses(ctx, crd, r)
+	p2pAddresses, err := fullnode.CollectExternalP2P(ctx, crd, r)
 	if err != nil {
 		p2pAddresses = make(fullnode.ExternalAddresses)
 		errs.Append(err)

--- a/controllers/cosmosfullnode_controller.go
+++ b/controllers/cosmosfullnode_controller.go
@@ -262,18 +262,6 @@ func (r *CosmosFullNodeReconciler) SetupWithManager(ctx context.Context, mgr ctr
 	if err != nil {
 		return fmt.Errorf("service index field %s: %w", controllerOwnerField, err)
 	}
-	err = mgr.GetFieldIndexer().IndexField(
-		ctx,
-		&corev1.Service{},
-		".spec.type",
-		func(obj client.Object) []string {
-			svc := obj.(*corev1.Service)
-			return []string{string(svc.Spec.Type)}
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("service index field .spec.type: %w", err)
-	}
 
 	cbuilder := ctrl.NewControllerManagedBy(mgr).For(&cosmosv1.CosmosFullNode{})
 

--- a/controllers/cosmosfullnode_controller.go
+++ b/controllers/cosmosfullnode_controller.go
@@ -181,6 +181,7 @@ func (r *CosmosFullNodeReconciler) resultWithErr(crd *cosmosv1.CosmosFullNode, e
 	if err.IsTransient() {
 		r.recorder.Event(crd, kube.EventWarning, "ErrorTransient", fmt.Sprintf("%v; retrying.", err))
 		crd.Status.StatusMessage = ptr(fmt.Sprintf("Transient error: system is retrying: %v", err))
+		crd.Status.Phase = cosmosv1.FullNodePhaseTransientError
 		return requeueResult, err
 	}
 

--- a/internal/fullnode/p2p_test.go
+++ b/internal/fullnode/p2p_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/samber/lo"
@@ -13,69 +14,80 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestCollectP2PAddresses(t *testing.T) {
+func TestCollectExternalP2P(t *testing.T) {
 	t.Parallel()
 
-	type (
-		mockSvcClient = mockClient[*corev1.Service]
-	)
-	stubSvcs := lo.Map(lo.Range(3), func(i, _ int) corev1.Service {
-		var stubSvc corev1.Service
-		stubSvc.Name = "stub" + strconv.Itoa(i)
-		stubSvc.Labels = map[string]string{kube.InstanceLabel: fmt.Sprintf("instance-%d", i)}
-		stubSvc.Status = corev1.ServiceStatus{
+	type mockSvcClient = mockClient[*corev1.Service]
+	ctx := context.Background()
+
+	t.Run("happy path", func(t *testing.T) {
+		stubSvcs := lo.Map(lo.Range(3), func(i, _ int) corev1.Service {
+			var stubSvc corev1.Service
+			stubSvc.Name = "stub" + strconv.Itoa(i)
+			stubSvc.Labels = map[string]string{kube.InstanceLabel: fmt.Sprintf("instance-%d", i)}
+			stubSvc.Status = corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{IP: fmt.Sprintf("0.0.0.%d", i), Hostname: "should not see me"},
+					},
+				},
+			}
+			return stubSvc
+		})
+
+		var hostSvc corev1.Service
+		hostSvc.Name = "stub-host"
+		hostSvc.Labels = map[string]string{kube.InstanceLabel: "instance-3"}
+		hostSvc.Status = corev1.ServiceStatus{
 			LoadBalancer: corev1.LoadBalancerStatus{
 				Ingress: []corev1.LoadBalancerIngress{
-					{IP: fmt.Sprintf("0.0.0.%d", i), Hostname: "should not see me"},
+					{Hostname: "host.example.com"},
 				},
 			},
 		}
-		return stubSvc
+
+		var missing corev1.Service
+		missing.Name = "stub-missing"
+		missing.Labels = map[string]string{kube.InstanceLabel: "instance-4"}
+
+		var mClient mockSvcClient
+		mClient.ObjectList = corev1.ServiceList{Items: append(stubSvcs, hostSvc, missing)}
+
+		crd := defaultCRD()
+		crd.Namespace = "addresses"
+		crd.Name = "simapp"
+
+		got, err := CollectExternalP2P(ctx, &crd, &mClient)
+		require.NoError(t, err)
+
+		want := ExternalAddresses{
+			"instance-0": "0.0.0.0:26656",
+			"instance-1": "0.0.0.1:26656",
+			"instance-2": "0.0.0.2:26656",
+			"instance-3": "host.example.com:26656",
+			"instance-4": "",
+		}
+		require.Equal(t, want, got)
+
+		require.Len(t, mClient.GotListOpts, 3)
+		var listOpt client.ListOptions
+		for _, opt := range mClient.GotListOpts {
+			opt.ApplyToList(&listOpt)
+		}
+		require.Equal(t, "addresses", listOpt.Namespace)
+		require.Zero(t, listOpt.Limit)
+		require.Equal(t, "app.kubernetes.io/component=p2p", listOpt.LabelSelector.String())
+		require.ElementsMatch(t, []string{".spec.type=LoadBalancer", ".metadata.controller=simapp"}, strings.Split(listOpt.FieldSelector.String(), ","))
 	})
 
-	var hostSvc corev1.Service
-	hostSvc.Name = "stub-host"
-	hostSvc.Labels = map[string]string{kube.InstanceLabel: "instance-3"}
-	hostSvc.Status = corev1.ServiceStatus{
-		LoadBalancer: corev1.LoadBalancerStatus{
-			Ingress: []corev1.LoadBalancerIngress{
-				{Hostname: "host.example.com"},
-			},
-		},
-	}
+	t.Run("zero state", func(t *testing.T) {
+		crd := defaultCRD()
+		var mClient mockSvcClient
+		got, err := CollectExternalP2P(ctx, &crd, &mClient)
 
-	var missing corev1.Service
-	missing.Name = "stub-missing"
-	missing.Labels = map[string]string{kube.InstanceLabel: "instance-4"}
-
-	var mClient mockSvcClient
-	mClient.ObjectList = corev1.ServiceList{Items: append(stubSvcs, hostSvc, missing)}
-
-	crd := defaultCRD()
-	crd.Namespace = "addresses"
-	crd.Name = "simapp"
-
-	got, err := CollectP2PAddresses(context.Background(), &crd, &mClient)
-	require.NoError(t, err)
-
-	want := ExternalAddresses{
-		"instance-0": "0.0.0.0:26656",
-		"instance-1": "0.0.0.1:26656",
-		"instance-2": "0.0.0.2:26656",
-		"instance-3": "host.example.com:26656",
-		"instance-4": "",
-	}
-	require.Equal(t, want, got)
-
-	require.Len(t, mClient.GotListOpts, 3)
-	var listOpt client.ListOptions
-	for _, opt := range mClient.GotListOpts {
-		opt.ApplyToList(&listOpt)
-	}
-	require.Equal(t, "addresses", listOpt.Namespace)
-	require.Zero(t, listOpt.Limit)
-	require.Equal(t, "app.kubernetes.io/component=p2p", listOpt.LabelSelector.String())
-	require.Equal(t, ".metadata.controller=simapp", listOpt.FieldSelector.String())
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
 }
 
 func TestExternalAddresses_Incomplete(t *testing.T) {

--- a/internal/fullnode/service_builder.go
+++ b/internal/fullnode/service_builder.go
@@ -60,7 +60,6 @@ func BuildServices(crd *cosmosv1.CosmosFullNode) []diff.Resource[*corev1.Service
 			svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
 		} else {
 			svc.Spec.Type = corev1.ServiceTypeClusterIP
-			svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
 		}
 
 		p2ps[i] = diff.Adapt(&svc, i)

--- a/internal/fullnode/service_builder.go
+++ b/internal/fullnode/service_builder.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const maxP2PServiceDefault = 1
+const maxP2PServiceDefault = int32(1)
 
 // BuildServices returns a list of services given the crd.
 //
@@ -27,13 +27,13 @@ const maxP2PServiceDefault = 1
 func BuildServices(crd *cosmosv1.CosmosFullNode) []diff.Resource[*corev1.Service] {
 	max := maxP2PServiceDefault
 	if v := crd.Spec.Service.MaxP2PExternalAddresses; v != nil {
-		max = int(*v)
+		max = *v
 	}
-	maxp2p := lo.Clamp(max, 0, int(crd.Spec.Replicas))
-	p2ps := make([]diff.Resource[*corev1.Service], maxp2p)
+	maxExternal := lo.Clamp(max, 0, crd.Spec.Replicas)
+	p2ps := make([]diff.Resource[*corev1.Service], crd.Spec.Replicas)
 
-	for i := range lo.Range(maxp2p) {
-		ordinal := int32(i)
+	for i := int32(0); i < crd.Spec.Replicas; i++ {
+		ordinal := i
 		var svc corev1.Service
 		svc.Name = p2pServiceName(crd, ordinal)
 		svc.Namespace = crd.Namespace
@@ -54,8 +54,14 @@ func BuildServices(crd *cosmosv1.CosmosFullNode) []diff.Resource[*corev1.Service
 			},
 		}
 		svc.Spec.Selector = map[string]string{kube.InstanceLabel: instanceName(crd, ordinal)}
-		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-		svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+
+		if i < maxExternal {
+			svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+			svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+		} else {
+			svc.Spec.Type = corev1.ServiceTypeClusterIP
+			svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
+		}
 
 		p2ps[i] = diff.Adapt(&svc, i)
 	}

--- a/internal/fullnode/service_builder_test.go
+++ b/internal/fullnode/service_builder_test.go
@@ -54,9 +54,8 @@ func TestBuildServices(t *testing.T) {
 						TargetPort: intstr.FromString("p2p"),
 					},
 				},
-				Selector:              map[string]string{"app.kubernetes.io/instance": fmt.Sprintf("terra-%d", i)},
-				Type:                  corev1.ServiceTypeClusterIP,
-				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+				Selector: map[string]string{"app.kubernetes.io/instance": fmt.Sprintf("terra-%d", i)},
+				Type:     corev1.ServiceTypeClusterIP,
 			}
 
 			require.Equal(t, wantSpec, p2p.Spec)
@@ -83,7 +82,7 @@ func TestBuildServices(t *testing.T) {
 
 		got := gotP2P[2].Object()
 		require.Equal(t, corev1.ServiceTypeClusterIP, got.Spec.Type)
-		require.Equal(t, corev1.ServiceExternalTrafficPolicyTypeCluster, got.Spec.ExternalTrafficPolicy)
+		require.Empty(t, got.Spec.ExternalTrafficPolicy)
 	})
 
 	t.Run("rpc service", func(t *testing.T) {

--- a/internal/fullnode/service_builder_test.go
+++ b/internal/fullnode/service_builder_test.go
@@ -1,6 +1,7 @@
 package fullnode
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -24,66 +25,65 @@ func TestBuildServices(t *testing.T) {
 		crd.Namespace = "test"
 		crd.Spec.ChainSpec.Network = "testnet"
 		crd.Spec.PodTemplate.Image = "terra:v6.0.0"
+		crd.Spec.Service.MaxP2PExternalAddresses = ptr(int32(0))
 		svcs := BuildServices(&crd)
 
-		require.Equal(t, 2, len(svcs)) // Includes single rpc service.
+		require.Equal(t, 4, len(svcs)) // 3 p2p services + 1 rpc service
 
-		p2p := svcs[0].Object()
-		require.Equal(t, "terra-p2p-0", p2p.Name)
-		require.Equal(t, "test", p2p.Namespace)
+		for i, svc := range svcs[:3] {
+			p2p := svc.Object()
+			require.Equal(t, fmt.Sprintf("terra-p2p-%d", i), p2p.Name)
+			require.Equal(t, "test", p2p.Namespace)
 
-		wantLabels := map[string]string{
-			"app.kubernetes.io/created-by": "cosmos-operator",
-			"app.kubernetes.io/name":       "terra",
-			"app.kubernetes.io/component":  "p2p",
-			"app.kubernetes.io/version":    "v6.0.0",
-			"app.kubernetes.io/instance":   "terra-0",
-			"cosmos.strange.love/network":  "testnet",
-		}
-		require.Equal(t, wantLabels, p2p.Labels)
+			wantLabels := map[string]string{
+				"app.kubernetes.io/created-by": "cosmos-operator",
+				"app.kubernetes.io/name":       "terra",
+				"app.kubernetes.io/component":  "p2p",
+				"app.kubernetes.io/version":    "v6.0.0",
+				"app.kubernetes.io/instance":   fmt.Sprintf("terra-%d", i),
+				"cosmos.strange.love/network":  "testnet",
+			}
+			require.Equal(t, wantLabels, p2p.Labels)
 
-		wantSpec := corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "p2p",
-					Protocol:   corev1.ProtocolTCP,
-					Port:       26656,
-					TargetPort: intstr.FromString("p2p"),
+			wantSpec := corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "p2p",
+						Protocol:   corev1.ProtocolTCP,
+						Port:       26656,
+						TargetPort: intstr.FromString("p2p"),
+					},
 				},
-			},
-			Selector:              map[string]string{"app.kubernetes.io/instance": "terra-0"},
-			Type:                  "LoadBalancer",
-			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
-		}
+				Selector:              map[string]string{"app.kubernetes.io/instance": fmt.Sprintf("terra-%d", i)},
+				Type:                  corev1.ServiceTypeClusterIP,
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+			}
 
-		require.Equal(t, wantSpec, p2p.Spec)
+			require.Equal(t, wantSpec, p2p.Spec)
+		}
 	})
 
 	t.Run("p2p max external addresses", func(t *testing.T) {
 		crd := defaultCRD()
-		crd.Spec.Replicas = 10
-
-		for i := 0; i < 5; i++ {
-			crd.Spec.Service.MaxP2PExternalAddresses = ptr(int32(i))
-			svcs := BuildServices(&crd)
-
-			got := lo.Filter(svcs, func(s diff.Resource[*corev1.Service], _ int) bool {
-				return s.Object().Labels[kube.ComponentLabel] == "p2p"
-			})
-
-			require.Equal(t, i, len(got))
-		}
-
-		crd.Spec.Replicas = 1
+		crd.Spec.Replicas = 3
 		crd.Spec.Service.MaxP2PExternalAddresses = ptr(int32(2))
 
 		svcs := BuildServices(&crd)
 
-		got := lo.Filter(svcs, func(s diff.Resource[*corev1.Service], _ int) bool {
+		gotP2P := lo.Filter(svcs, func(s diff.Resource[*corev1.Service], _ int) bool {
 			return s.Object().Labels[kube.ComponentLabel] == "p2p"
 		})
 
-		require.Equal(t, 1, len(got))
+		require.Equal(t, 3, len(gotP2P))
+		for i, svc := range gotP2P[:2] {
+			p2p := svc.Object()
+			require.Equal(t, corev1.ServiceTypeLoadBalancer, p2p.Spec.Type, i)
+			require.Equal(t, corev1.ServiceExternalTrafficPolicyTypeLocal, p2p.Spec.ExternalTrafficPolicy, i)
+		}
+
+		got := gotP2P[2].Object()
+		require.Equal(t, corev1.ServiceTypeClusterIP, got.Spec.Type)
+		require.Equal(t, corev1.ServiceExternalTrafficPolicyTypeCluster, got.Spec.ExternalTrafficPolicy)
 	})
 
 	t.Run("rpc service", func(t *testing.T) {

--- a/internal/fullnode/service_control_test.go
+++ b/internal/fullnode/service_control_test.go
@@ -43,8 +43,8 @@ func TestServiceControl_Reconcile(t *testing.T) {
 		require.Zero(t, listOpt.Limit)
 		require.Equal(t, ".metadata.controller=osmosis", listOpt.FieldSelector.String())
 
-		require.Equal(t, 1, mClient.CreateCount)
-		require.Equal(t, "osmosis-p2p-1", mClient.LastCreateObject.Name)
+		require.Equal(t, 2, mClient.CreateCount) // Created 2 p2p services.
+		require.Equal(t, "osmosis-p2p-2", mClient.LastCreateObject.Name)
 		require.NotEmpty(t, mClient.LastCreateObject.OwnerReferences)
 		require.Equal(t, crd.Name, mClient.LastCreateObject.OwnerReferences[0].Name)
 		require.Equal(t, "CosmosFullNode", mClient.LastCreateObject.OwnerReferences[0].Kind)


### PR DESCRIPTION
Starts https://github.com/strangelove-ventures/cosmos-operator/issues/42

We now create a p2p service for each pod. But only some of them are of type: LoadBalancer depending on how the user configures the spec.

The long-term plan (in a future PR) is that we will use the service DNS names to be the private peers. 

We could use the pod IPs directly. However, this will cause potentially infinite thrashing. As pods are destroyed/created with new IPs, the config.toml will need to be updated for each new set of pod IPs which in turn will cause a pod destroy/recreate. Services give us a stable address (i.e. the DNS name).