### PR TITLE
fix: Reduce some logging and event noise

### DIFF
--- a/controllers/cosmosfullnode_controller.go
+++ b/controllers/cosmosfullnode_controller.go
@@ -115,7 +115,7 @@ func (r *CosmosFullNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// K8S can create pods first even if the PVC isn't ready. Pods won't be in a ready state until PVC is bound.
 
 	// Create or update Services.
-	err := r.serviceControl.Reconcile(ctx, logger, crd)
+	err := r.serviceControl.Reconcile(ctx, reporter, crd)
 	if err != nil {
 		errs.Append(err)
 	}
@@ -132,7 +132,7 @@ func (r *CosmosFullNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		p2pAddresses = make(fullnode.ExternalAddresses)
 		errs.Append(err)
 	}
-	configCksums, err := r.configMapControl.Reconcile(ctx, logger, crd, p2pAddresses)
+	configCksums, err := r.configMapControl.Reconcile(ctx, reporter, crd, p2pAddresses)
 	if err != nil {
 		errs.Append(err)
 	}

--- a/controllers/selfhealing_controller.go
+++ b/controllers/selfhealing_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
@@ -81,13 +82,13 @@ func (r *SelfHealingReconciler) pvcAutoScale(ctx context.Context, reporter kube.
 	usage, err := r.diskClient.CollectDiskUsage(ctx, crd)
 	if err != nil {
 		reporter.Error(err, "Failed to collect pvc disk usage")
-		reporter.RecordError("PVCAutoScaleCollectUsage", err)
+		reporter.RecordError("PVCAutoScaleCollectUsage", errors.New("failed to collect pvc disk usage"))
 		return
 	}
 	didSignal, err := r.pvcAutoScaler.SignalPVCResize(ctx, crd, usage)
 	if err != nil {
 		reporter.Error(err, "Failed to signal pvc resize")
-		reporter.RecordError("PVCAutoScaleSignalResize", err)
+		reporter.RecordError("PVCAutoScaleSignalResize", errors.New("failed to signal pvc resize"))
 		return
 	}
 	if !didSignal {

--- a/controllers/selfhealing_controller.go
+++ b/controllers/selfhealing_controller.go
@@ -82,13 +82,14 @@ func (r *SelfHealingReconciler) pvcAutoScale(ctx context.Context, reporter kube.
 	usage, err := r.diskClient.CollectDiskUsage(ctx, crd)
 	if err != nil {
 		reporter.Error(err, "Failed to collect pvc disk usage")
+		// This error can be noisy so we record a generic error. Check logs for error details.
 		reporter.RecordError("PVCAutoScaleCollectUsage", errors.New("failed to collect pvc disk usage"))
 		return
 	}
 	didSignal, err := r.pvcAutoScaler.SignalPVCResize(ctx, crd, usage)
 	if err != nil {
 		reporter.Error(err, "Failed to signal pvc resize")
-		reporter.RecordError("PVCAutoScaleSignalResize", errors.New("failed to signal pvc resize"))
+		reporter.RecordError("PVCAutoScaleSignalResize", err)
 		return
 	}
 	if !didSignal {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/exp v0.0.0-20220921164117-439092de6870
 	golang.org/x/sync v0.1.0
@@ -89,6 +88,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 // indirect

--- a/internal/cosmos/pod_filter.go
+++ b/internal/cosmos/pod_filter.go
@@ -41,17 +41,17 @@ func (filter PodFilter) SyncedPods(ctx context.Context, log kube.Logger, candida
 			fields := []interface{}{"pod", pod.Name}
 			ip := pod.Status.PodIP
 			if ip == "" {
-				log.Info("Pod has no IP", fields...)
+				log.Debug("Pod has no IP", fields...)
 				return nil
 			}
 			host := fmt.Sprintf("http://%s:26657", ip)
 			resp, err := filter.tendermint.Status(ctx, host)
 			if err != nil {
-				log.Info("Failed to fetch tendermint rpc status", append(fields, "error", err)...)
+				log.Debug("Failed to fetch tendermint rpc status", append(fields, "error", err)...)
 				return nil
 			}
 			if resp.Result.SyncInfo.CatchingUp {
-				log.Info("Pod is catching up", fields...)
+				log.Debug("Pod is catching up", fields...)
 				return nil
 			}
 			inSync[i] = pod

--- a/internal/cosmos/pod_filter_test.go
+++ b/internal/cosmos/pod_filter_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/samber/lo"
+	"github.com/strangelove-ventures/cosmos-operator/internal/test"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -17,7 +17,7 @@ func (fn mockStatuser) Status(ctx context.Context, rpcHost string) (TendermintSt
 	return fn(ctx, rpcHost)
 }
 
-var nopLogger = logr.Discard()
+var nopLogger test.NopReporter
 
 func TestPodFilter_SyncedPods(t *testing.T) {
 	t.Parallel()

--- a/internal/fullnode/pvc_auto_scaler.go
+++ b/internal/fullnode/pvc_auto_scaler.go
@@ -2,13 +2,13 @@ package fullnode
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
 
 	"github.com/samber/lo"
 	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
-	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -108,12 +108,12 @@ func (scaler PVCAutoScaler) calcNextCapacity(current resource.Quantity, increase
 		return quantity, nil
 	}
 
-	multierr.AppendInto(&merr, err)
+	merr = errors.Join(merr, err)
 
 	// Then try to calc by resource quantity
 	addtl, err := resource.ParseQuantity(increase)
 	if err != nil {
-		return quantity, multierr.Append(merr, err)
+		return quantity, errors.Join(merr, err)
 	}
 
 	return *resource.NewQuantity(current.Value()+addtl.Value(), current.Format), nil

--- a/internal/fullnode/pvc_disk_usage.go
+++ b/internal/fullnode/pvc_disk_usage.go
@@ -11,7 +11,6 @@ import (
 	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
 	"github.com/strangelove-ventures/cosmos-operator/internal/healthcheck"
 	"github.com/strangelove-ventures/cosmos-operator/internal/kube"
-	"go.uber.org/multierr"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -96,7 +95,7 @@ func (c DiskUsageCollector) CollectDiskUsage(ctx context.Context, crd *cosmosv1.
 		return item != nil
 	})
 	if len(errs) == len(pods.Items) {
-		return nil, multierr.Combine(errs...)
+		return nil, errors.Join(errs...)
 	}
 
 	return lo.Compact(found), nil

--- a/internal/kube/reporter.go
+++ b/internal/kube/reporter.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 )
@@ -14,6 +15,7 @@ const (
 // Logger is a structured logger
 type Logger interface {
 	Info(msg string, keysAndValues ...interface{})
+	Debug(msg string, keysAndValues ...interface{})
 	Error(err error, msg string, keysAndValues ...interface{})
 }
 
@@ -24,6 +26,19 @@ type Reporter interface {
 	RecordError(reason string, err error)
 }
 
+// ToLogger converts a logr.Logger to a Logger.
+func ToLogger(log logr.Logger) Logger {
+	return logger{log}
+}
+
+type logger struct {
+	logr.Logger
+}
+
+func (l logger) Debug(msg string, keysAndValues ...interface{}) {
+	l.V(1).Info(msg, keysAndValues...)
+}
+
 // EventReporter both logs and records events.
 type EventReporter struct {
 	log      Logger
@@ -31,8 +46,8 @@ type EventReporter struct {
 	resource runtime.Object
 }
 
-func NewEventReporter(logger Logger, recorder record.EventRecorder, resource runtime.Object) EventReporter {
-	return EventReporter{log: logger, recorder: recorder, resource: resource}
+func NewEventReporter(logger logr.Logger, recorder record.EventRecorder, resource runtime.Object) EventReporter {
+	return EventReporter{log: ToLogger(logger), recorder: recorder, resource: resource}
 }
 
 // Error logs as an error log entry.
@@ -43,6 +58,11 @@ func (r EventReporter) Error(err error, msg string, keysAndValues ...interface{}
 // Info logs as an info log entry.
 func (r EventReporter) Info(msg string, keysAndValues ...interface{}) {
 	r.log.Info(msg, keysAndValues...)
+}
+
+// Debug logs as a debug log entry.
+func (r EventReporter) Debug(msg string, keysAndValues ...interface{}) {
+	r.log.Debug(msg, keysAndValues...)
 }
 
 // RecordError records a warning event.

--- a/internal/test/mock_reporter.go
+++ b/internal/test/mock_reporter.go
@@ -4,6 +4,7 @@ package test
 type NopReporter struct{}
 
 func (n NopReporter) Info(msg string, keysAndValues ...interface{})             {}
+func (n NopReporter) Debug(msg string, keysAndValues ...interface{})            {}
 func (n NopReporter) Error(err error, msg string, keysAndValues ...interface{}) {}
 func (n NopReporter) RecordInfo(reason, msg string)                             {}
 func (n NopReporter) RecordError(reason string, err error)                      {}

--- a/internal/volsnapshot/vol_snapshot_control.go
+++ b/internal/volsnapshot/vol_snapshot_control.go
@@ -2,6 +2,7 @@ package volsnapshot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -12,7 +13,6 @@ import (
 	cosmosalpha "github.com/strangelove-ventures/cosmos-operator/api/v1alpha1"
 	"github.com/strangelove-ventures/cosmos-operator/internal/fullnode"
 	"github.com/strangelove-ventures/cosmos-operator/internal/kube"
-	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -159,7 +159,7 @@ func (control VolumeSnapshotControl) DeleteOldSnapshots(ctx context.Context, log
 		vs := vs
 		log.Info("Deleting volume snapshot", "volumeSnapshotName", vs.Name, "limit", limit)
 		if err := control.client.Delete(ctx, &vs); kube.IgnoreNotFound(err) != nil {
-			multierr.AppendInto(&merr, fmt.Errorf("delete %s: %w", vs.Name, err))
+			merr = errors.Join(merr, fmt.Errorf("delete %s: %w", vs.Name, err))
 		}
 	}
 	return merr

--- a/internal/volsnapshot/vol_snapshot_control.go
+++ b/internal/volsnapshot/vol_snapshot_control.go
@@ -65,7 +65,7 @@ func (control VolumeSnapshotControl) FindCandidate(ctx context.Context, crd *cos
 	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	var (
-		synced     = control.podFilter.SyncedPods(cctx, logger, ptrSlice(pods.Items))
+		synced     = control.podFilter.SyncedPods(cctx, kube.ToLogger(logger), ptrSlice(pods.Items))
 		availCount = int32(len(synced))
 		minAvail   = crd.Spec.MinAvailable
 	)

--- a/internal/volsnapshot/vol_snapshot_control_test.go
+++ b/internal/volsnapshot/vol_snapshot_control_test.go
@@ -465,6 +465,6 @@ func TestVolumeSnapshotControl_DeleteOldSnapshots(t *testing.T) {
 		err := control.DeleteOldSnapshots(ctx, nopLogger, &crd)
 
 		require.Error(t, err)
-		require.EqualError(t, err, "delete 1: oops; delete 0: oops")
+		require.EqualError(t, err, "delete 1: oops\ndelete 0: oops")
 	})
 }


### PR DESCRIPTION
Closes https://github.com/strangelove-ventures/cosmos-operator/issues/272

Introduces a `Debug` log method. Removes `multierr` in favor of the now native `errors.Join`. 