### PR TITLE
feat(ScheduledVolumeSnapshot): Take snapshot without removing pod

### DIFF
--- a/api/v1alpha1/scheduledvolumesnapshot_types.go
+++ b/api/v1alpha1/scheduledvolumesnapshot_types.go
@@ -69,6 +69,7 @@ type ScheduledVolumeSnapshotSpec struct {
 	DeletePod bool `json:"deletePod"`
 
 	// Minimum number of CosmosFullNode pods that must be ready before creating a VolumeSnapshot.
+	// This field has no effect unless spec.deletePod=true.
 	// This controller gracefully deletes a pod while taking a snapshot. Then recreates the pod once the
 	// snapshot is complete.
 	// This way, the snapshot has the highest possible data integrity.

--- a/api/v1alpha1/scheduledvolumesnapshot_types.go
+++ b/api/v1alpha1/scheduledvolumesnapshot_types.go
@@ -69,7 +69,7 @@ type ScheduledVolumeSnapshotSpec struct {
 	DeletePod bool `json:"deletePod"`
 
 	// Minimum number of CosmosFullNode pods that must be ready before creating a VolumeSnapshot.
-	// This field has no effect unless spec.deletePod=true.
+	// In the future, this field will have no effect unless spec.deletePod=true.
 	// This controller gracefully deletes a pod while taking a snapshot. Then recreates the pod once the
 	// snapshot is complete.
 	// This way, the snapshot has the highest possible data integrity.

--- a/api/v1alpha1/scheduledvolumesnapshot_types.go
+++ b/api/v1alpha1/scheduledvolumesnapshot_types.go
@@ -62,6 +62,12 @@ type ScheduledVolumeSnapshotSpec struct {
 	// The name of the VolumeSnapshotClass to use when creating snapshots.
 	VolumeSnapshotClassName string `json:"volumeSnapshotClassName"`
 
+	// If true, the controller will temporarily delete the candidate pod before taking a snapshot of the pod's associated PVC.
+	// This option prevents writes to the PVC, ensuring the highest possible data integrity.
+	// Once the snapshot is created, the pod will be restored.
+	// +optional
+	DeletePod bool `json:"deletePod"`
+
 	// Minimum number of CosmosFullNode pods that must be ready before creating a VolumeSnapshot.
 	// This controller gracefully deletes a pod while taking a snapshot. Then recreates the pod once the
 	// snapshot is complete.

--- a/config/crd/bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
+++ b/config/crd/bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
@@ -85,11 +85,11 @@ spec:
                 type: integer
               minAvailable:
                 description: 'Minimum number of CosmosFullNode pods that must be ready
-                  before creating a VolumeSnapshot. This controller gracefully deletes
-                  a pod while taking a snapshot. Then recreates the pod once the snapshot
-                  is complete. This way, the snapshot has the highest possible data
-                  integrity. Defaults to 2. Warning: If set to 1, you will experience
-                  downtime.'
+                  before creating a VolumeSnapshot. This field has no effect unless
+                  spec.deletePod=true. This controller gracefully deletes a pod while
+                  taking a snapshot. Then recreates the pod once the snapshot is complete.
+                  This way, the snapshot has the highest possible data integrity.
+                  Defaults to 2. Warning: If set to 1, you will experience downtime.'
                 format: int32
                 minimum: 1
                 type: integer

--- a/config/crd/bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
+++ b/config/crd/bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
@@ -54,6 +54,12 @@ spec:
               is created at a time, so at most only 1 pod is temporarily deleted.
               Multiple, parallel VolumeSnapshots are not supported.'
             properties:
+              deletePod:
+                description: If true, the controller will temporarily delete the candidate
+                  pod before taking a snapshot of the pod's associated PVC. This option
+                  prevents writes to the PVC, ensuring the highest possible data integrity.
+                  Once the snapshot is created, the pod will be restored.
+                type: boolean
               fullNodeRef:
                 description: Reference to the source CosmosFullNode. This field is
                   immutable. If you change the fullnode, you may encounter undefined

--- a/config/crd/bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
+++ b/config/crd/bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
@@ -85,11 +85,12 @@ spec:
                 type: integer
               minAvailable:
                 description: 'Minimum number of CosmosFullNode pods that must be ready
-                  before creating a VolumeSnapshot. This field has no effect unless
-                  spec.deletePod=true. This controller gracefully deletes a pod while
-                  taking a snapshot. Then recreates the pod once the snapshot is complete.
-                  This way, the snapshot has the highest possible data integrity.
-                  Defaults to 2. Warning: If set to 1, you will experience downtime.'
+                  before creating a VolumeSnapshot. In the future, this field will
+                  have no effect unless spec.deletePod=true. This controller gracefully
+                  deletes a pod while taking a snapshot. Then recreates the pod once
+                  the snapshot is complete. This way, the snapshot has the highest
+                  possible data integrity. Defaults to 2. Warning: If set to 1, you
+                  will experience downtime.'
                 format: int32
                 minimum: 1
                 type: integer

--- a/controllers/scheduledvolumesnapshot_controller.go
+++ b/controllers/scheduledvolumesnapshot_controller.go
@@ -121,8 +121,11 @@ func (r *ScheduledVolumeSnapshotReconciler) Reconcile(ctx context.Context, req c
 			r.reportError(crd, "FindCandidateError", err)
 			return retryResult, nil
 		}
-		crd.Status.Phase = cosmosv1alpha1.SnapshotPhaseDeletingPod
 		crd.Status.Candidate = &candidate
+		crd.Status.Phase = cosmosv1alpha1.SnapshotPhaseCreating
+		if crd.Spec.DeletePod {
+			crd.Status.Phase = cosmosv1alpha1.SnapshotPhaseDeletingPod
+		}
 
 	case cosmosv1alpha1.SnapshotPhaseDeletingPod:
 		logger.Info(string(phase))


### PR DESCRIPTION
Starts https://github.com/strangelove-ventures/cosmos-operator/issues/275

## Backwards Breaking

This changes the default where removing the pod must be configured by the user. The new default behavior is to keep the pod and create a snapshot as the pod is still reading/writing to the PVC. As a reminder, ScheduledVolumeSnapshot is still alpha, so breaking changes are allowed. 

## Known Limitations

When we're not removing a pod, it doesn't make sense to care about if pods are in sync or not. Synced pods are a concern when removing a pod because we do not want to cause downtime. 

A followup PR will address this limitation. 