### PR TITLE
fix: Only use current pods when fetching cached data

### DIFF
--- a/internal/cosmos/cache_controller.go
+++ b/internal/cosmos/cache_controller.go
@@ -156,6 +156,7 @@ func (c *CacheController) Collect(ctx context.Context, controller client.ObjectK
 		return nil
 	}
 	v, _ := c.cache.Get(controller)
+	IntersectPods(&v, pods)
 	for i := range pods {
 		UpsertPod(&v, &pods[i])
 	}

--- a/internal/cosmos/cache_controller_test.go
+++ b/internal/cosmos/cache_controller_test.go
@@ -2,6 +2,7 @@ package cosmos
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"go.uber.org/goleak"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -32,6 +34,7 @@ func (m *mockCollector) Collect(ctx context.Context, pods []corev1.Pod) StatusCo
 }
 
 type mockReader struct {
+	sync.Mutex
 	GetErr error
 
 	ListPods []corev1.Pod
@@ -39,6 +42,8 @@ type mockReader struct {
 }
 
 func (m *mockReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	m.Lock()
+	defer m.Unlock()
 	if ctx == nil {
 		panic("nil context")
 	}
@@ -50,6 +55,8 @@ func (m *mockReader) Get(ctx context.Context, key client.ObjectKey, obj client.O
 }
 
 func (m *mockReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	m.Lock()
+	defer m.Unlock()
 	if ctx == nil {
 		panic("nil context")
 	}
@@ -59,11 +66,19 @@ func (m *mockReader) List(ctx context.Context, list client.ObjectList, opts ...c
 }
 
 func TestCacheController_Reconcile(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	const (
 		namespace = "strangelove"
 		name      = "nolus"
 	)
+
+	validStatusColl := StatusCollection{
+		{pod: new(corev1.Pod)},
+		{pod: new(corev1.Pod)},
+		{pod: new(corev1.Pod)},
+	}
 
 	t.Run("crd created or updated", func(t *testing.T) {
 		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
@@ -73,7 +88,7 @@ func TestCacheController_Reconcile(t *testing.T) {
 		reader.ListPods = pods
 
 		var collector mockCollector
-		collector.StubCollection = make(StatusCollection, 3)
+		collector.StubCollection = validStatusColl
 
 		controller := NewCacheController(&collector, &reader, nil)
 
@@ -120,7 +135,7 @@ func TestCacheController_Reconcile(t *testing.T) {
 		reader.ListPods = pods
 
 		var collector mockCollector
-		collector.StubCollection = make(StatusCollection, 1)
+		collector.StubCollection = validStatusColl[:1]
 
 		controller := NewCacheController(&collector, reader, nil)
 
@@ -140,12 +155,13 @@ func TestCacheController_Reconcile(t *testing.T) {
 		_, err = controller.Reconcile(ctx, req)
 		require.NoError(t, err)
 
+		reader.ListPods = nil
 		require.Empty(t, controller.Collect(ctx, key))
 
 		require.NoError(t, controller.Close())
 	})
 
-	t.Run("not cached yet", func(t *testing.T) {
+	t.Run("zero state", func(t *testing.T) {
 		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 		var reader mockReader
@@ -156,5 +172,80 @@ func TestCacheController_Reconcile(t *testing.T) {
 		key := client.ObjectKey{Name: name, Namespace: namespace}
 		require.Empty(t, controller.Collect(ctx, key))
 		require.Empty(t, controller.SyncedPods(ctx, key))
+	})
+}
+
+func TestCacheController_SyncedPods(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	const (
+		namespace = "default"
+		name      = "axelar"
+	)
+
+	t.Run("more pods than cache", func(t *testing.T) {
+		reader := new(mockReader)
+		reader.ListPods = make([]corev1.Pod, 2)
+
+		var catchingUp CometStatus
+		catchingUp.Result.SyncInfo.CatchingUp = true
+
+		var collector mockCollector
+		collector.StubCollection = StatusCollection{
+			{pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "1"}}},
+			{pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "2"}}, status: catchingUp},
+		}
+
+		controller := NewCacheController(&collector, reader, nil)
+
+		var req reconcile.Request
+		req.Name = name
+		req.Namespace = namespace
+		_, err := controller.Reconcile(ctx, req)
+		require.NoError(t, err)
+
+		key := client.ObjectKey{Name: name, Namespace: namespace}
+		require.Eventually(t, func() bool {
+			return len(controller.Collect(ctx, key)) > 1
+		}, time.Second, time.Millisecond)
+
+		readyStatus := corev1.PodStatus{Conditions: []corev1.PodCondition{
+			{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Second))}},
+		}
+		pods := []corev1.Pod{
+			{ObjectMeta: metav1.ObjectMeta{UID: "1"}, Status: readyStatus},
+			{ObjectMeta: metav1.ObjectMeta{UID: "2"}},
+			{ObjectMeta: metav1.ObjectMeta{UID: "3"}},
+		}
+		reader.ListPods = pods
+
+		gotColl := controller.Collect(ctx, key)
+		require.Len(t, gotColl, 3)
+
+		_, err = gotColl[2].Status()
+		require.Error(t, err)
+		require.EqualError(t, err, "missing status")
+
+		gotPods := controller.SyncedPods(ctx, key)
+		require.Len(t, gotPods, 1)
+		require.Equal(t, pods[0], *gotPods[0])
+
+		opts := reader.ListOpts
+		require.Len(t, opts, 2)
+		var listOpt client.ListOptions
+		for _, opt := range opts {
+			opt.ApplyToList(&listOpt)
+		}
+		require.Equal(t, namespace, listOpt.Namespace)
+		require.Zero(t, listOpt.Limit)
+		require.Equal(t, ".metadata.controller=axelar", listOpt.FieldSelector.String())
+
+		require.NoError(t, controller.Close())
+	})
+
+	t.Run("less pods than cache", func(t *testing.T) {
+		// TODO: should remove pods in cache that do not match the live list
+		t.Fail()
 	})
 }

--- a/internal/cosmos/status_collection.go
+++ b/internal/cosmos/status_collection.go
@@ -1,6 +1,8 @@
 package cosmos
 
 import (
+	"errors"
+
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -25,7 +27,21 @@ func (status StatusItem) Status() (CometStatus, error) {
 // StatusCollection is a list of pods and CometBFT status associated with the pod.
 type StatusCollection []StatusItem
 
-func (coll StatusCollection) Default() StatusCollection { return make(StatusCollection, 0) }
+// UpsertPod updates the pod in the collection or adds an item to the collection if it does not exist.
+// All operations are performed in-place.
+func UpsertPod(coll *StatusCollection, pod *corev1.Pod) {
+	if *coll == nil {
+		*coll = make(StatusCollection, 0)
+	}
+	for i, p := range *coll {
+		if p.Pod().UID == pod.UID {
+			item := (*coll)[i]
+			(*coll)[i] = StatusItem{pod: pod, err: item.err, status: item.status}
+			return
+		}
+	}
+	*coll = append(*coll, StatusItem{pod: pod, err: errors.New("missing status")})
+}
 
 // Pods returns all pods.
 func (coll StatusCollection) Pods() []*corev1.Pod {

--- a/internal/cosmos/status_collection.go
+++ b/internal/cosmos/status_collection.go
@@ -45,7 +45,7 @@ func UpsertPod(coll *StatusCollection, pod *corev1.Pod) {
 }
 
 // IntersectPods removes all pods from the collection that are not in the given list.
-func IntersectPods(coll *StatusCollection, pods []*corev1.Pod) {
+func IntersectPods(coll *StatusCollection, pods []corev1.Pod) {
 	if *coll == nil {
 		*coll = make(StatusCollection, 0)
 		return

--- a/internal/cosmos/status_collection_test.go
+++ b/internal/cosmos/status_collection_test.go
@@ -51,3 +51,25 @@ func TestUpsertPod(t *testing.T) {
 	UpsertPod(&coll, &corev1.Pod{})
 	require.Len(t, coll, 2)
 }
+
+func TestIntersectPods(t *testing.T) {
+	t.Parallel()
+
+	var coll StatusCollection
+	var pod corev1.Pod
+	pod.UID = "1"
+
+	IntersectPods(&coll, []*corev1.Pod{&pod})
+	require.NotNil(t, coll)
+	require.Len(t, coll, 0)
+
+	var pod2 corev1.Pod
+	pod2.UID = "2"
+
+	coll = append(coll, StatusItem{pod: &pod})
+	coll = append(coll, StatusItem{pod: &pod2})
+
+	IntersectPods(&coll, []*corev1.Pod{&pod})
+	require.Len(t, coll, 1)
+	require.Equal(t, "1", string(coll[0].Pod().UID))
+}

--- a/internal/cosmos/status_collection_test.go
+++ b/internal/cosmos/status_collection_test.go
@@ -31,3 +31,23 @@ func TestStatusCollection_SyncedPods(t *testing.T) {
 	require.Len(t, coll.SyncedPods(), 1)
 	require.Equal(t, "in-sync", coll.SyncedPods()[0].Name)
 }
+
+func TestUpsertPod(t *testing.T) {
+	t.Parallel()
+
+	var coll StatusCollection
+	var pod corev1.Pod
+	pod.UID = "1"
+	UpsertPod(&coll, &pod)
+
+	require.Len(t, coll, 1)
+
+	pod.Name = "new"
+	UpsertPod(&coll, &pod)
+
+	require.Len(t, coll, 1)
+	require.Equal(t, "new", coll[0].Pod().Name)
+
+	UpsertPod(&coll, &corev1.Pod{})
+	require.Len(t, coll, 2)
+}

--- a/internal/cosmos/status_collection_test.go
+++ b/internal/cosmos/status_collection_test.go
@@ -59,7 +59,7 @@ func TestIntersectPods(t *testing.T) {
 	var pod corev1.Pod
 	pod.UID = "1"
 
-	IntersectPods(&coll, []*corev1.Pod{&pod})
+	IntersectPods(&coll, []corev1.Pod{pod})
 	require.NotNil(t, coll)
 	require.Len(t, coll, 0)
 
@@ -69,7 +69,7 @@ func TestIntersectPods(t *testing.T) {
 	coll = append(coll, StatusItem{pod: &pod})
 	coll = append(coll, StatusItem{pod: &pod2})
 
-	IntersectPods(&coll, []*corev1.Pod{&pod})
+	IntersectPods(&coll, []corev1.Pod{pod})
 	require.Len(t, coll, 1)
 	require.Equal(t, "1", string(coll[0].Pod().UID))
 }


### PR DESCRIPTION
Closes https://github.com/strangelove-ventures/cosmos-operator/issues/273

The cache controller always uses the most recent pods and collects cached Comet statuses only. 

This prevents stale cache errors such as:
* Taking down all pods on a rollout because the cached pods are all ready. 
* Prevents scenarios where pods have been added or removed since the time the pods have been cached.