### PR TITLE
fix(CacheController): Data race in test

### DIFF
--- a/internal/cosmos/cache_controller_test.go
+++ b/internal/cosmos/cache_controller_test.go
@@ -156,9 +156,6 @@ func TestCacheController_Reconcile(t *testing.T) {
 		_, err = controller.Reconcile(ctx, req)
 		require.NoError(t, err)
 
-		reader.ListPods = nil
-		require.Empty(t, controller.Collect(ctx, key))
-
 		require.NoError(t, controller.Close())
 	})
 


### PR DESCRIPTION
Closes https://github.com/strangelove-ventures/cosmos-operator/issues/320

The data race was inherent only to the tests. 

I'm not sure why I was testing that last use case (may have been a mistake). We test zero state in another subtest which should cover our bases there.

Stress test results:
```
❯ go test -race -c ./internal/cosmos && stress ./cosmos.test
5s: 733 runs so far, 0 failures
10s: 1515 runs so far, 0 failures
15s: 2293 runs so far, 0 failures
20s: 3065 runs so far, 0 failures
25s: 3814 runs so far, 0 failures
30s: 4583 runs so far, 0 failures
35s: 5356 runs so far, 0 failures
40s: 6101 runs so far, 0 failures
45s: 6861 runs so far, 0 failures
50s: 7640 runs so far, 0 failures
55s: 8375 runs so far, 0 failures
1m0s: 9108 runs so far, 0 failures
1m5s: 9851 runs so far, 0 failures
1m10s: 10606 runs so far, 0 failures
1m15s: 11354 runs so far, 0 failures
1m20s: 12110 runs so far, 0 failures
1m25s: 12869 runs so far, 0 failures
1m30s: 13626 runs so far, 0 failures
1m35s: 14366 runs so far, 0 failures
1m40s: 15115 runs so far, 0 failures
1m45s: 15874 runs so far, 0 failures
1m50s: 16640 runs so far, 0 failures
1m55s: 17404 runs so far, 0 failures
2m0s: 18143 runs so far, 0 failures
2m5s: 18855 runs so far, 0 failures
2m10s: 19607 runs so far, 0 failures
2m15s: 20364 runs so far, 0 failures
2m20s: 21137 runs so far, 0 failures
2m25s: 21901 runs so far, 0 failures
2m30s: 22661 runs so far, 0 failures
2m35s: 23422 runs so far, 0 failures
2m40s: 24159 runs so far, 0 failures
2m45s: 24916 runs so far, 0 failures
2m50s: 25649 runs so far, 0 failures
2m55s: 26386 runs so far, 0 failures
3m0s: 27142 runs so far, 0 failures
3m5s: 27871 runs so far, 0 failures
3m10s: 28633 runs so far, 0 failures
3m15s: 29399 runs so far, 0 failures
3m20s: 30159 runs so far, 0 failures
```