### PR TITLE
fix(CosmosFullNode): Log pod name not the entire pod

### DIFF
--- a/controllers/selfhealing_controller.go
+++ b/controllers/selfhealing_controller.go
@@ -124,11 +124,11 @@ func (r *SelfHealingReconciler) mitigateHeightDrift(ctx context.Context, reporte
 	for _, pod := range pods {
 		// CosmosFullNodeController will detect missing pod and re-create it.
 		if err := r.Delete(ctx, pod); kube.IgnoreNotFound(err) != nil {
-			reporter.Error(err, "Failed to delete pod", "pod", pod)
+			reporter.Error(err, "Failed to delete pod", "pod", pod.Name)
 			reporter.RecordError("HeightDriftMitigationDeletePod", err)
 			continue
 		}
-		reporter.Info("Deleted pod for meeting height drift threshold", "pod", pod)
+		reporter.Info("Deleted pod for meeting height drift threshold", "pod", pod.Name)
 		deleted++
 	}
 	if deleted > 0 {


### PR DESCRIPTION
Because otherwise the log line is super long and bad DX as it prints the entire pod object.