### PR TITLE
fix: Don't require VolumeSnapshot CRDs to run the manager

### DIFF
--- a/api/v1alpha1/scheduledvolumesnapshot_types.go
+++ b/api/v1alpha1/scheduledvolumesnapshot_types.go
@@ -166,6 +166,9 @@ const (
 
 	// SnapshotPhaseSuspended means the controller is not creating snapshots. Suspended by the user.
 	SnapshotPhaseSuspended SnapshotPhase = "Suspended"
+
+	// SnapshotPhaseMissingCRDs means the controller is not creating snapshots. The required VolumeSnapshot CRDs are missing.
+	SnapshotPhaseMissingCRDs SnapshotPhase = "MissingCRDs"
 )
 
 type VolumeSnapshotStatus struct {

--- a/main.go
+++ b/main.go
@@ -218,6 +218,7 @@ func startManager(cmd *cobra.Command, args []string) error {
 		mgr.GetEventRecorderFor(cosmosv1alpha1.ScheduledVolumeSnapshotController),
 		statusClient,
 		cacheController,
+		snapshotErr != nil,
 	).SetupWithManager(ctx, mgr); err != nil {
 		return fmt.Errorf("unable to create ScheduledVolumeSnapshot controller: %w", err)
 	}


### PR DESCRIPTION
Closes https://github.com/strangelove-ventures/cosmos-operator/issues/326

Without VolumeSnapshot CRDs, the entire operator process crashes.

Since VolumeSnapshots for supporting controllers (not for CosmosFullNode), I don't think crashing is appropriate. Instead it will run and report errors in appropriate places.