### PR TITLE
add fresh init container to cleanup tmp dir

### DIFF
--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -278,7 +278,7 @@ func initContainers(crd *cosmosv1.CosmosFullNode, moniker string) []corev1.Conta
 	initCmd := fmt.Sprintf("%s init %s --chain-id %s", binary, moniker, crd.Spec.ChainSpec.ChainID)
 	required := []corev1.Container{
 		{
-			Name:            "fresh-init",
+			Name:            "clean-init",
 			Image:           infraToolImage,
 			Command:         []string{"sh"},
 			Args:            []string{"-c", `rm -rf "$HOME/.tmp/*"`},

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -278,6 +278,15 @@ func initContainers(crd *cosmosv1.CosmosFullNode, moniker string) []corev1.Conta
 	initCmd := fmt.Sprintf("%s init %s --chain-id %s", binary, moniker, crd.Spec.ChainSpec.ChainID)
 	required := []corev1.Container{
 		{
+			Name:            "fresh-init",
+			Image:           infraToolImage,
+			Command:         []string{"sh"},
+			Args:            []string{"-c",`rm -rf "$HOME/.tmp"`},
+			Env:             envVars,
+			ImagePullPolicy: tpl.ImagePullPolicy,
+			WorkingDir:      workDir,
+		},
+		{
 			Name:    "chain-init",
 			Image:   tpl.Image,
 			Command: []string{"sh"},

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -281,7 +281,7 @@ func initContainers(crd *cosmosv1.CosmosFullNode, moniker string) []corev1.Conta
 			Name:            "fresh-init",
 			Image:           infraToolImage,
 			Command:         []string{"sh"},
-			Args:            []string{"-c",`rm -rf "$HOME/.tmp"`},
+			Args:            []string{"-c", `rm -rf "$HOME/.tmp/*"`},
 			Env:             envVars,
 			ImagePullPolicy: tpl.ImagePullPolicy,
 			WorkingDir:      workDir,

--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -509,7 +509,7 @@ gaiad start --home /home/operator/cosmos`
 		require.Equal(t, "/foo", extraVol[0].MountPath)
 
 		initConts := lo.SliceToMap(pod.Spec.InitContainers, func(c corev1.Container) (string, corev1.Container) { return c.Name, c })
-		require.ElementsMatch(t, []string{"fresh-init", "chain-init", "new-init", "genesis-init", "config-merge"}, lo.Keys(initConts))
+		require.ElementsMatch(t, []string{"clean-init", "chain-init", "new-init", "genesis-init", "config-merge"}, lo.Keys(initConts))
 		require.Equal(t, "foo:latest", initConts["chain-init"].Image)
 	})
 }


### PR DESCRIPTION
When pods are not shut down cleanly, tmp dir is not wiped, causing failure to start up again.
Requires another init container, but it uses the same infra-toolkit image, so negligible time is added to pod init routine.

Resolves #329 