### PR TITLE
feat(CosmosFullNode): Allow configuring the chain home directory

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -415,12 +415,11 @@ type ChainSpec struct {
 	// +kubebuilder:validation:MinLength:=1
 	Binary string `json:"binary"`
 
-	// The chain's home directory where the chain's data and config is stored.
+	// The chain's home directory is where the chain's data and config is stored.
 	// This should be a single folder. E.g. .gaia, .dydxprotocol, .osmosisd, etc.
 	// Set via --home flag when running the binary.
 	// If empty, defaults to "cosmos" which translates to `chain start --home /home/operator/cosmos`.
-	// Historically, several chains do not respect the --home flag or introduce bugs which forces use
-	// of the default home directory.
+	// Historically, several chains do not respect the --home and save data outside --home which crashes the pods.
 	// Therefore, this option was introduced to mitigate those edge cases, so that you can specify the home directory
 	// to match the chain's default home dir.
 	// +optional

--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -415,6 +415,17 @@ type ChainSpec struct {
 	// +kubebuilder:validation:MinLength:=1
 	Binary string `json:"binary"`
 
+	// The chain's home directory where the chain's data and config is stored.
+	// This should be a single folder. E.g. .gaia, .dydxprotocol, .osmosisd, etc.
+	// Set via --home flag when running the binary.
+	// If empty, defaults to "cosmos" which translates to `chain start --home /home/operator/cosmos`.
+	// Historically, several chains do not respect the --home flag or introduce bugs which forces use
+	// of the default home directory.
+	// Therefore, this option was introduced to mitigate those edge cases, so that you can specify the home directory
+	// to match the chain's default home dir.
+	// +optional
+	HomeDir string `json:"homeDir"`
+
 	// CometBFT (formerly Tendermint) configuration applied to config.toml.
 	// Although optional, it's highly recommended you configure this field.
 	// +optional

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -223,16 +223,15 @@ spec:
                       format or genesis location.'
                     type: string
                   homeDir:
-                    description: The chain's home directory where the chain's data
+                    description: The chain's home directory is where the chain's data
                       and config is stored. This should be a single folder. E.g. .gaia,
                       .dydxprotocol, .osmosisd, etc. Set via --home flag when running
                       the binary. If empty, defaults to "cosmos" which translates
                       to `chain start --home /home/operator/cosmos`. Historically,
-                      several chains do not respect the --home flag or introduce bugs
-                      which forces use of the default home directory. Therefore, this
-                      option was introduced to mitigate those edge cases, so that
-                      you can specify the home directory to match the chain's default
-                      home dir.
+                      several chains do not respect the --home and save data outside
+                      --home which crashes the pods. Therefore, this option was introduced
+                      to mitigate those edge cases, so that you can specify the home
+                      directory to match the chain's default home dir.
                     type: string
                   logFormat:
                     description: One of plain or json. If not set, defaults to plain.

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -222,6 +222,18 @@ spec:
                       .zip Use GenesisScript if the chain has an unconventional file
                       format or genesis location.'
                     type: string
+                  homeDir:
+                    description: The chain's home directory where the chain's data
+                      and config is stored. This should be a single folder. E.g. .gaia,
+                      .dydxprotocol, .osmosisd, etc. Set via --home flag when running
+                      the binary. If empty, defaults to "cosmos" which translates
+                      to `chain start --home /home/operator/cosmos`. Historically,
+                      several chains do not respect the --home flag or introduce bugs
+                      which forces use of the default home directory. Therefore, this
+                      option was introduced to mitigate those edge cases, so that
+                      you can specify the home directory to match the chain's default
+                      home dir.
+                    type: string
                   logFormat:
                     description: One of plain or json. If not set, defaults to plain.
                     enum:

--- a/config/samples/cosmos_v1_cosmosfullnode_full.yaml
+++ b/config/samples/cosmos_v1_cosmosfullnode_full.yaml
@@ -14,6 +14,7 @@ spec:
     network: mainnet
     chainID: cosmoshub-4
     binary: gaiad
+    homeDir: .gaia # optional, defaults to "cosmos"
     skipInvariants: true
     genesisURL: "https://github.com/cosmos/mainnet/raw/master/genesis.cosmoshub-4.json.gz"
     genesisScript: "arbitrary script to download genesis file. e.g. curl https://url-to-genesis.com | jq '.genesis' > $GENESIS_FILE"

--- a/healtcheck_cmd.go
+++ b/healtcheck_cmd.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/strangelove-ventures/cosmos-operator/internal/cosmos"
-	"github.com/strangelove-ventures/cosmos-operator/internal/fullnode"
 	"github.com/strangelove-ventures/cosmos-operator/internal/healthcheck"
 	"golang.org/x/sync/errgroup"
 )
@@ -49,14 +48,9 @@ func startHealthCheckServer(cmd *cobra.Command, args []string) error {
 	)
 	defer func() { _ = zlog.Sync() }()
 
-	var (
-		tm   = healthcheck.NewComet(logger, cometClient, rpcHost, timeout)
-		disk = healthcheck.DiskUsage(fullnode.ChainHomeDir)
-	)
-
 	mux := http.NewServeMux()
-	mux.Handle("/", tm)
-	mux.Handle("/disk", disk)
+	mux.Handle("/", healthcheck.NewComet(logger, cometClient, rpcHost, timeout))
+	mux.HandleFunc("/disk", healthcheck.DiskUsage)
 
 	srv := &http.Server{
 		Addr:         listenAddr,

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -250,7 +250,8 @@ func (b PodBuilder) WithOrdinal(ordinal int32) PodBuilder {
 const (
 	workDir = "/home/operator"
 	// ChainHomeDir is the abs filepath for the chain's home directory.
-	ChainHomeDir = workDir + "/cosmos"
+	// TODO: Temporary path
+	ChainHomeDir = workDir + "/.sentinelhub"
 
 	tmpDir         = workDir + "/.tmp"
 	tmpConfigDir   = workDir + "/.config"

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -391,7 +391,7 @@ func startCmdAndArgs(crd *cosmosv1.CosmosFullNode) (string, []string) {
 }
 
 func startCommandArgs(crd *cosmosv1.CosmosFullNode) []string {
-	args := []string{"start", "--home", `"$CHAIN_HOME"`}
+	args := []string{"start", "--home", ChainHomeDir(crd)}
 	cfg := crd.Spec.ChainSpec
 	if cfg.SkipInvariants {
 		args = append(args, "--x-crisis-skip-assert-invariants")

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -250,8 +250,7 @@ func (b PodBuilder) WithOrdinal(ordinal int32) PodBuilder {
 const (
 	workDir = "/home/operator"
 	// ChainHomeDir is the abs filepath for the chain's home directory.
-	// TODO: Temporary path
-	ChainHomeDir = workDir + "/.sentinelhub"
+	ChainHomeDir = workDir + "/cosmos"
 
 	tmpDir         = workDir + "/.tmp"
 	tmpConfigDir   = workDir + "/.config"

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -391,7 +391,7 @@ func startCmdAndArgs(crd *cosmosv1.CosmosFullNode) (string, []string) {
 }
 
 func startCommandArgs(crd *cosmosv1.CosmosFullNode) []string {
-	args := []string{"start", "--home", ChainHomeDir(crd)}
+	args := []string{"start", "--home", `"$CHAIN_HOME"`}
 	cfg := crd.Spec.ChainSpec
 	if cfg.SkipInvariants {
 		args = append(args, "--x-crisis-skip-assert-invariants")

--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -222,7 +222,7 @@ func TestPodBuilder(t *testing.T) {
 		require.Equal(t, startContainer.Env[3].Value, "/home/operator/cosmos/config")
 		require.Equal(t, startContainer.Env[4].Name, "DATA_DIR")
 		require.Equal(t, startContainer.Env[4].Value, "/home/operator/cosmos/data")
-		require.Equal(t, envVars, startContainer.Env)
+		require.Equal(t, envVars(&crd), startContainer.Env)
 
 		healthContainer := pod.Spec.Containers[1]
 		require.Equal(t, "healthcheck", healthContainer.Name)
@@ -252,7 +252,7 @@ func TestPodBuilder(t *testing.T) {
 		}))
 
 		for _, c := range pod.Spec.InitContainers {
-			require.Equal(t, envVars, startContainer.Env, c.Name)
+			require.Equal(t, envVars(&crd), startContainer.Env, c.Name)
 			require.Equal(t, wantWrkDir, c.WorkingDir)
 		}
 
@@ -512,6 +512,14 @@ gaiad start --home /home/operator/cosmos`
 		require.ElementsMatch(t, []string{"clean-init", "chain-init", "new-init", "genesis-init", "config-merge"}, lo.Keys(initConts))
 		require.Equal(t, "foo:latest", initConts["chain-init"].Image)
 	})
+}
+
+func TestChainHomeDir(t *testing.T) {
+	crd := defaultCRD()
+	require.Equal(t, "/home/operator/cosmos", ChainHomeDir(&crd))
+
+	crd.Spec.ChainSpec.HomeDir = ".gaia"
+	require.Equal(t, "/home/operator/.gaia", ChainHomeDir(&crd))
 }
 
 func TestPVCName(t *testing.T) {

--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -363,7 +363,7 @@ func TestPodBuilder(t *testing.T) {
 		require.Equal(t, "ghcr.io/cosmoshub:v1.2.3", c.Image)
 
 		require.Equal(t, []string{"gaiad"}, c.Command)
-		require.Equal(t, []string{"start", "--home", "/home/operator/cosmos"}, c.Args)
+		require.Equal(t, []string{"start", "--home", `"$CHAIN_HOME"`}, c.Args)
 
 		cmdCrd.Spec.ChainSpec.SkipInvariants = true
 		pod, err = NewPodBuilder(&cmdCrd).WithOrdinal(1).Build()
@@ -371,7 +371,7 @@ func TestPodBuilder(t *testing.T) {
 		c = pod.Spec.Containers[0]
 
 		require.Equal(t, []string{"gaiad"}, c.Command)
-		require.Equal(t, []string{"start", "--home", "/home/operator/cosmos", "--x-crisis-skip-assert-invariants"}, c.Args)
+		require.Equal(t, []string{"start", "--home", `"$CHAIN_HOME"`, "--x-crisis-skip-assert-invariants"}, c.Args)
 
 		cmdCrd.Spec.ChainSpec.LogLevel = ptr("debug")
 		cmdCrd.Spec.ChainSpec.LogFormat = ptr("json")
@@ -379,7 +379,7 @@ func TestPodBuilder(t *testing.T) {
 		require.NoError(t, err)
 		c = pod.Spec.Containers[0]
 
-		require.Equal(t, []string{"start", "--home", "/home/operator/cosmos", "--x-crisis-skip-assert-invariants", "--log_level", "debug", "--log_format", "json"}, c.Args)
+		require.Equal(t, []string{"start", "--home", `"$CHAIN_HOME"`, "--x-crisis-skip-assert-invariants", "--log_level", "debug", "--log_format", "json"}, c.Args)
 	})
 
 	t.Run("sentry start container command ", func(t *testing.T) {
@@ -393,7 +393,7 @@ func TestPodBuilder(t *testing.T) {
 
 		require.Equal(t, []string{"sh"}, c.Command)
 		const wantBody1 = `sleep 10
-gaiad start --home /home/operator/cosmos`
+gaiad start --home "$CHAIN_HOME"`
 		require.Equal(t, []string{"-c", wantBody1}, c.Args)
 
 		cmdCrd.Spec.ChainSpec.PrivvalSleepSeconds = ptr(int32(60))
@@ -402,7 +402,7 @@ gaiad start --home /home/operator/cosmos`
 		c = pod.Spec.Containers[0]
 
 		const wantBody2 = `sleep 60
-gaiad start --home /home/operator/cosmos`
+gaiad start --home "$CHAIN_HOME"`
 		require.Equal(t, []string{"-c", wantBody2}, c.Args)
 
 		cmdCrd.Spec.ChainSpec.PrivvalSleepSeconds = ptr(int32(0))

--- a/internal/fullnode/pvc_disk_usage.go
+++ b/internal/fullnode/pvc_disk_usage.go
@@ -19,7 +19,7 @@ import (
 
 // DiskUsager fetches disk usage statistics
 type DiskUsager interface {
-	DiskUsage(ctx context.Context, host string) (healthcheck.DiskUsageResponse, error)
+	DiskUsage(ctx context.Context, host, homeDir string) (healthcheck.DiskUsageResponse, error)
 }
 
 type PVCDiskUsage struct {
@@ -66,7 +66,7 @@ func (c DiskUsageCollector) CollectDiskUsage(ctx context.Context, crd *cosmosv1.
 			pod := pods.Items[i]
 			cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			defer cancel()
-			resp, err := c.diskClient.DiskUsage(cctx, "http://"+pod.Status.PodIP)
+			resp, err := c.diskClient.DiskUsage(cctx, "http://"+pod.Status.PodIP, ChainHomeDir(crd))
 			if err != nil {
 				errs[i] = fmt.Errorf("pod %s %s: %w", pod.Name, resp.Dir, err)
 				return nil

--- a/internal/healthcheck/client.go
+++ b/internal/healthcheck/client.go
@@ -24,7 +24,7 @@ func NewClient(client *http.Client) *Client {
 
 // DiskUsage returns disk usage statistics or an error if unable to obtain.
 // Do not include the port in the host.
-func (c Client) DiskUsage(ctx context.Context, host string) (DiskUsageResponse, error) {
+func (c Client) DiskUsage(ctx context.Context, host, homeDir string) (DiskUsageResponse, error) {
 	var diskResp DiskUsageResponse
 	u, err := url.Parse(host)
 	if err != nil {
@@ -37,6 +37,11 @@ func (c Client) DiskUsage(ctx context.Context, host string) (DiskUsageResponse, 
 	if err != nil {
 		return diskResp, fmt.Errorf("new request: %w", err)
 	}
+
+	q := req.URL.Query()
+	q.Set("dir", homeDir)
+	req.URL.RawQuery = q.Encode()
+
 	resp, err := c.httpDo(req)
 	if err != nil {
 		return diskResp, fmt.Errorf("http do: %w", err)

--- a/internal/healthcheck/disk_usage.go
+++ b/internal/healthcheck/disk_usage.go
@@ -18,29 +18,34 @@ type DiskUsageResponse struct {
 
 // DiskUsage returns a handler which responds with disk statistics in JSON.
 // Path is the filesystem path from which to check disk usage.
-func DiskUsage(dir string) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		var resp DiskUsageResponse
-		resp.Dir = dir
-		var fs syscall.Statfs_t
-		// Purposefully not adding test hook, so tests may catch OS issues.
-		err := syscall.Statfs(filepath.Clean(dir), &fs)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			resp.Error = err.Error()
-			mustJSONEncode(resp, w)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
-		var (
-			all  = fs.Blocks * uint64(fs.Bsize)
-			free = fs.Bfree * uint64(fs.Bsize)
-		)
-		resp.AllBytes = all
-		resp.FreeBytes = free
+func DiskUsage(w http.ResponseWriter, r *http.Request) {
+	var resp DiskUsageResponse
+	dir := r.URL.Query().Get("dir")
+	if dir == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		resp.Error = "query param dir must be specified"
 		mustJSONEncode(resp, w)
+		return
 	}
+	resp.Dir = dir
+	var fs syscall.Statfs_t
+	// Purposefully not adding test hook, so tests may catch OS issues.
+	err := syscall.Statfs(filepath.Clean(dir), &fs)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		resp.Error = err.Error()
+		mustJSONEncode(resp, w)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	var (
+		all  = fs.Blocks * uint64(fs.Bsize)
+		free = fs.Bfree * uint64(fs.Bsize)
+	)
+	resp.AllBytes = all
+	resp.FreeBytes = free
+	mustJSONEncode(resp, w)
 }
 
 func mustJSONEncode(v interface{}, w io.Writer) {


### PR DESCRIPTION
Closes https://github.com/strangelove-ventures/cosmos-operator/issues/341

There's been too many instances where chains still persist data outside of the `--home` flag. 

Notably: Osmosis, DYDX, and now DVPN/Sentinel.

So we can't rely on chains to respect the user's intentions. 

This feature allows the user to optionally configure the chain home. 

Unfortunately, we can't reliably derive the home path because no chains use a common convention. 