### PR TITLE
fix: Bump memory to handle many deployments

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,7 +58,7 @@ spec:
             name: pprof
         resources:
           limits:
-            memory: 64Mi
+            memory: 128Mi
           requests:
             cpu: 50m
             memory: 64Mi


### PR DESCRIPTION
We found that when the operator manages many CosmosFullNodes, OOMs started happening.