### PR TITLE
Add image override

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  generate:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -1,4 +1,4 @@
-name: Verify Manifests
+name: Kube Manifests
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  generate:
+  verify:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -1,0 +1,22 @@
+name: Verify Manifests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.20.2'
+      - run: make generate manifests
+
+      - uses: CatChen/check-git-status-action@v1
+        with:
+          fail-if-not-clean: true

--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -696,6 +696,10 @@ type InstanceOverridesSpec struct {
 	// Overrides an individual instance's PVC.
 	// +optional
 	VolumeClaimTemplate *PersistentVolumeClaimSpec `json:"volumeClaimTemplate"`
+
+	// Overrides an individual instance's Image.
+	// +optional
+	Image string `json:"image"`
 }
 
 type DisableStrategy string

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -312,6 +312,9 @@ spec:
                       - Pod
                       - All
                       type: string
+                    image:
+                      description: Overrides an individual instance's Image.
+                      type: string
                     volumeClaimTemplate:
                       description: Overrides an individual instance's PVC.
                       properties:

--- a/internal/fullnode/build_pods.go
+++ b/internal/fullnode/build_pods.go
@@ -22,14 +22,16 @@ func BuildPods(crd *cosmosv1.CosmosFullNode, cksums ConfigChecksums) ([]diff.Res
 		if err != nil {
 			return nil, err
 		}
-		if disable := overrides[pod.Name].DisableStrategy; disable != nil {
-			continue
+		if o, ok := overrides[pod.Name]; ok {
+			if o.DisableStrategy != nil {
+				continue
+			}
+			if o.Image != "" {
+				pod.Spec.Containers[0].Image = o.Image
+			}
 		}
 		if _, shouldSnapshot := candidates[pod.Name]; shouldSnapshot {
 			continue
-		}
-		if image := overrides[pod.Name].Image; image != "" {
-			pod.Spec.Containers[0].Image = image
 		}
 		pod.Annotations[configChecksumAnnotation] = cksums[client.ObjectKeyFromObject(pod)]
 		pods = append(pods, diff.Adapt(pod, i))

--- a/internal/fullnode/build_pods.go
+++ b/internal/fullnode/build_pods.go
@@ -30,13 +30,22 @@ func BuildPods(crd *cosmosv1.CosmosFullNode, cksums ConfigChecksums) ([]diff.Res
 				continue
 			}
 			if o.Image != "" {
-				pod.Spec.Containers[0].Image = o.Image
+				setMainContainerImage(pod, o.Image)
 			}
 		}
 		pod.Annotations[configChecksumAnnotation] = cksums[client.ObjectKeyFromObject(pod)]
 		pods = append(pods, diff.Adapt(pod, i))
 	}
 	return pods, nil
+}
+
+func setMainContainerImage(pod *corev1.Pod, image string) {
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == mainContainer {
+			pod.Spec.Containers[i].Image = image
+			return
+		}
+	}
 }
 
 func podCandidates(crd *cosmosv1.CosmosFullNode) map[string]struct{} {

--- a/internal/fullnode/build_pods.go
+++ b/internal/fullnode/build_pods.go
@@ -22,6 +22,9 @@ func BuildPods(crd *cosmosv1.CosmosFullNode, cksums ConfigChecksums) ([]diff.Res
 		if err != nil {
 			return nil, err
 		}
+		if _, shouldSnapshot := candidates[pod.Name]; shouldSnapshot {
+			continue
+		}
 		if o, ok := overrides[pod.Name]; ok {
 			if o.DisableStrategy != nil {
 				continue
@@ -29,9 +32,6 @@ func BuildPods(crd *cosmosv1.CosmosFullNode, cksums ConfigChecksums) ([]diff.Res
 			if o.Image != "" {
 				pod.Spec.Containers[0].Image = o.Image
 			}
-		}
-		if _, shouldSnapshot := candidates[pod.Name]; shouldSnapshot {
-			continue
 		}
 		pod.Annotations[configChecksumAnnotation] = cksums[client.ObjectKeyFromObject(pod)]
 		pods = append(pods, diff.Adapt(pod, i))

--- a/internal/fullnode/build_pods.go
+++ b/internal/fullnode/build_pods.go
@@ -25,6 +25,9 @@ func BuildPods(crd *cosmosv1.CosmosFullNode, cksums ConfigChecksums) ([]diff.Res
 		if disable := overrides[pod.Name].DisableStrategy; disable != nil {
 			continue
 		}
+		if image := overrides[pod.Name].Image; image != "" {
+			pod.Spec.Containers[0].Image = image
+		}
 		if _, shouldSnapshot := candidates[pod.Name]; shouldSnapshot {
 			continue
 		}

--- a/internal/fullnode/build_pods.go
+++ b/internal/fullnode/build_pods.go
@@ -25,11 +25,11 @@ func BuildPods(crd *cosmosv1.CosmosFullNode, cksums ConfigChecksums) ([]diff.Res
 		if disable := overrides[pod.Name].DisableStrategy; disable != nil {
 			continue
 		}
-		if image := overrides[pod.Name].Image; image != "" {
-			pod.Spec.Containers[0].Image = image
-		}
 		if _, shouldSnapshot := candidates[pod.Name]; shouldSnapshot {
 			continue
+		}
+		if image := overrides[pod.Name].Image; image != "" {
+			pod.Spec.Containers[0].Image = image
 		}
 		pod.Annotations[configChecksumAnnotation] = cksums[client.ObjectKeyFromObject(pod)]
 		pods = append(pods, diff.Adapt(pod, i))

--- a/internal/fullnode/build_pods_test.go
+++ b/internal/fullnode/build_pods_test.go
@@ -66,9 +66,13 @@ func TestBuildPods(t *testing.T) {
 			},
 			Spec: cosmosv1.FullNodeSpec{
 				Replicas: 6,
+				PodTemplate: cosmosv1.PodSpec{
+					Image: "agoric:latest",
+				},
 				InstanceOverrides: map[string]cosmosv1.InstanceOverridesSpec{
 					"agoric-2": {DisableStrategy: ptr(cosmosv1.DisablePod)},
 					"agoric-4": {DisableStrategy: ptr(cosmosv1.DisableAll)},
+					"agoric-5": {Image: "some_image:custom"},
 				},
 			},
 		}
@@ -82,6 +86,13 @@ func TestBuildPods(t *testing.T) {
 		})
 		got := lo.Map(pods, func(pod diff.Resource[*corev1.Pod], _ int) string { return pod.Object().Name })
 		require.Equal(t, want, got)
+		for _, pod := range pods {
+			if pod.Object().Name == "agoric-5" {
+				require.Equal(t, "some_image:custom", pod.Object().Spec.Containers[0].Image)
+			} else {
+				require.Equal(t, "agoric:latest", pods[0].Object().Spec.Containers[0].Image)
+			}
+		}
 	})
 
 	t.Run("scheduled volume snapshot pod candidate", func(t *testing.T) {

--- a/internal/fullnode/build_pods_test.go
+++ b/internal/fullnode/build_pods_test.go
@@ -60,8 +60,11 @@ func TestBuildPods(t *testing.T) {
 	})
 
 	t.Run("instance overrides", func(t *testing.T) {
-		image := "agoric:latest"
-		overrideImage := "some_image:custom"
+		const (
+			image         = "agoric:latest"
+			overrideImage = "some_image:custom"
+			overridePod   = "agoric-5"
+		)
 		crd := &cosmosv1.CosmosFullNode{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "agoric",
@@ -72,9 +75,9 @@ func TestBuildPods(t *testing.T) {
 					Image: image,
 				},
 				InstanceOverrides: map[string]cosmosv1.InstanceOverridesSpec{
-					"agoric-2": {DisableStrategy: ptr(cosmosv1.DisablePod)},
-					"agoric-4": {DisableStrategy: ptr(cosmosv1.DisableAll)},
-					"agoric-5": {Image: overrideImage},
+					"agoric-2":  {DisableStrategy: ptr(cosmosv1.DisablePod)},
+					"agoric-4":  {DisableStrategy: ptr(cosmosv1.DisableAll)},
+					overridePod: {Image: overrideImage},
 				},
 			},
 		}
@@ -90,7 +93,7 @@ func TestBuildPods(t *testing.T) {
 		require.Equal(t, want, got)
 		for _, pod := range pods {
 			image := pod.Object().Spec.Containers[0].Image
-			if pod.Object().Name == "agoric-5" {
+			if pod.Object().Name == overridePod {
 				require.Equal(t, overrideImage, image)
 			} else {
 				require.Equal(t, image, image)

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -21,7 +21,10 @@ import (
 
 var bufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
 
-const healthCheckPort = healthcheck.Port
+const (
+	healthCheckPort = healthcheck.Port
+	mainContainer   = "node"
+)
 
 // PodBuilder builds corev1.Pods
 type PodBuilder struct {
@@ -65,7 +68,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 			Containers: []corev1.Container{
 				// Main start container.
 				{
-					Name:  "node",
+					Name:  mainContainer,
 					Image: tpl.Image,
 					// The following is a useful hack if you need to inspect the PV.
 					//Command: []string{"/bin/sh"},


### PR DESCRIPTION
Allow user to override the image for a specific pod, useful if pods are at different sync heights during initial sync.