### PR TITLE
feat: add subdomain/hostname to pods created

### DIFF
--- a/internal/fullnode/build_pods.go
+++ b/internal/fullnode/build_pods.go
@@ -22,6 +22,8 @@ func BuildPods(crd *cosmosv1.CosmosFullNode, cksums ConfigChecksums) ([]diff.Res
 		if err != nil {
 			return nil, err
 		}
+		pod.Spec.Hostname = pod.Name
+		pod.Spec.Subdomain = crd.Name
 		if _, shouldSnapshot := candidates[pod.Name]; shouldSnapshot {
 			continue
 		}

--- a/internal/fullnode/build_pods.go
+++ b/internal/fullnode/build_pods.go
@@ -22,8 +22,6 @@ func BuildPods(crd *cosmosv1.CosmosFullNode, cksums ConfigChecksums) ([]diff.Res
 		if err != nil {
 			return nil, err
 		}
-		pod.Spec.Hostname = pod.Name
-		pod.Spec.Subdomain = crd.Name
 		if _, shouldSnapshot := candidates[pod.Name]; shouldSnapshot {
 			continue
 		}

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -180,8 +180,10 @@ func (b PodBuilder) WithOrdinal(ordinal int32) PodBuilder {
 
 	pod.Name = name
 	pod.Spec.InitContainers = initContainers(b.crd, name)
+
 	pod.Spec.Hostname = pod.Name
 	pod.Spec.Subdomain = b.crd.Name
+
 	pod.Spec.Volumes = []corev1.Volume{
 		{
 			Name: volChainHome,

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -181,7 +181,7 @@ func (b PodBuilder) WithOrdinal(ordinal int32) PodBuilder {
 	pod.Name = name
 	pod.Spec.InitContainers = initContainers(b.crd, name)
 	pod.Spec.Hostname = pod.Name
-
+	pod.Spec.Subdomain = b.crd.Name
 	pod.Spec.Volumes = []corev1.Volume{
 		{
 			Name: volChainHome,

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -65,6 +65,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 				FSGroupChangePolicy: ptr(corev1.FSGroupChangeOnRootMismatch),
 				SeccompProfile:      &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 			},
+			Subdomain: crd.Name,
 			Containers: []corev1.Container{
 				// Main start container.
 				{
@@ -179,6 +180,7 @@ func (b PodBuilder) WithOrdinal(ordinal int32) PodBuilder {
 
 	pod.Name = name
 	pod.Spec.InitContainers = initContainers(b.crd, name)
+	pod.Spec.Hostname = pod.Name
 
 	pod.Spec.Volumes = []corev1.Volume{
 		{

--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -56,6 +56,9 @@ func TestPodBuilder(t *testing.T) {
 		require.Equal(t, "test", pod.Namespace)
 		require.Equal(t, "osmosis-5", pod.Name)
 
+		require.Equal(t, "osmosis", pod.Spec.Subdomain)
+		require.Equal(t, "osmosis-5", pod.Spec.Hostname)
+
 		wantLabels := map[string]string{
 			"app.kubernetes.io/instance":   "osmosis-5",
 			"app.kubernetes.io/component":  "CosmosFullNode",


### PR DESCRIPTION
This PR adds hostname & subdomain to pods on creation (similar to how stateful sets do).
This is needed for a headless service to have podname.servicename... DNS resolution (instead of just servicename).
ala
`
root@harpoon-horcrux-1:/# host harpoon-0.harpoon
harpoon-0.harpoon.cosmos.svc.cluster.local has address 10.0.9.240

root@harpoon-horcrux-1:/# host harpoon-1.harpoon
harpoon-1.harpoon.cosmos.svc.cluster.local has address 10.0.7.151

root@harpoon-horcrux-1:/# host harpoon-2.harpoon
harpoon-2.harpoon.cosmos.svc.cluster.local has address 10.0.8.192

root@harpoon-horcrux-1:/# host harpoon
harpoon.cosmos.svc.cluster.local has address 10.0.7.151
harpoon.cosmos.svc.cluster.local has address 10.0.9.240
harpoon.cosmos.svc.cluster.local has address 10.0.8.192
`
before this patch only the last 'DNS' lookup would work.
I don't believe it has any negative effects