### PR TITLE
Backwards compatibility when spec.chain.versions is not populated

### DIFF
--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -208,7 +208,7 @@ func TestPodBuilder(t *testing.T) {
 		pod, err := builder.WithOrdinal(6).Build()
 		require.NoError(t, err)
 
-		require.Len(t, pod.Spec.Containers, 3)
+		require.Len(t, pod.Spec.Containers, 2)
 
 		startContainer := pod.Spec.Containers[0]
 		require.Equal(t, "node", startContainer.Name)
@@ -288,7 +288,7 @@ func TestPodBuilder(t *testing.T) {
 		pod, err := builder.WithOrdinal(6).Build()
 		require.NoError(t, err)
 
-		require.Len(t, pod.Spec.Containers, 3)
+		require.Len(t, pod.Spec.Containers, 2)
 
 		container := pod.Spec.Containers[0]
 		require.Equal(t, "node", container.Name)
@@ -347,7 +347,7 @@ func TestPodBuilder(t *testing.T) {
 		require.Equal(t, "osmosis-node-key-5", vols[4].Secret.SecretName)
 		require.Equal(t, []corev1.KeyToPath{{Key: "node_key.json", Path: "node_key.json"}}, vols[4].Secret.Items)
 
-		require.Equal(t, len(pod.Spec.Containers), 3)
+		require.Equal(t, len(pod.Spec.Containers), 2)
 
 		c := pod.Spec.Containers[0]
 		require.Equal(t, "node", c.Name) // Sanity check
@@ -523,7 +523,7 @@ gaiad start --home /home/operator/cosmos`
 			require.Nilf(t, cont.ReadinessProbe, "container %d", i)
 		}
 
-		require.Equal(t, 3, len(pod.Spec.Containers))
+		require.Equal(t, 2, len(pod.Spec.Containers))
 		require.Equal(t, "node", pod.Spec.Containers[0].Name)
 
 		sidecar := pod.Spec.Containers[1]


### PR DESCRIPTION
The periodic db version check sidecar should not be added when spec.chain.versions is not populated