### PR TITLE
Dont require podspec image

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -194,7 +194,10 @@ type PodSpec struct {
 
 	// Image is the docker reference in "repository:tag" format. E.g. busybox:latest.
 	// This is for the main container running the chain process.
+	// Note: for granular control over which images are applied at certain block heights,
+	// use spec.chain.versions instead.
 	// +kubebuilder:validation:MinLength:=1
+	// +optional
 	Image string `json:"image"`
 
 	// Image pull policy.

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -2616,9 +2616,11 @@ spec:
                       type: object
                     type: array
                   image:
-                    description: Image is the docker reference in "repository:tag"
+                    description: 'Image is the docker reference in "repository:tag"
                       format. E.g. busybox:latest. This is for the main container
-                      running the chain process.
+                      running the chain process. Note: for granular control over which
+                      images are applied at certain block heights, use spec.chain.versions
+                      instead.'
                     minLength: 1
                     type: string
                   imagePullPolicy:
@@ -5595,8 +5597,6 @@ spec:
                       - name
                       type: object
                     type: array
-                required:
-                - image
                 type: object
               replicas:
                 description: Number of replicas to create. Individual replicas have

--- a/internal/fullnode/build_pods.go
+++ b/internal/fullnode/build_pods.go
@@ -40,7 +40,7 @@ func BuildPods(crd *cosmosv1.CosmosFullNode, cksums ConfigChecksums) ([]diff.Res
 				image = version.Image
 			}
 			if image != "" {
-				setMainContainerImage(pod, image)
+				setChainContainerImage(pod, image)
 			}
 		}
 		if o, ok := overrides[pod.Name]; ok {
@@ -48,7 +48,7 @@ func BuildPods(crd *cosmosv1.CosmosFullNode, cksums ConfigChecksums) ([]diff.Res
 				continue
 			}
 			if o.Image != "" {
-				setMainContainerImage(pod, o.Image)
+				setChainContainerImage(pod, o.Image)
 			}
 		}
 		pod.Annotations[configChecksumAnnotation] = cksums[client.ObjectKeyFromObject(pod)]
@@ -57,11 +57,17 @@ func BuildPods(crd *cosmosv1.CosmosFullNode, cksums ConfigChecksums) ([]diff.Res
 	return pods, nil
 }
 
-func setMainContainerImage(pod *corev1.Pod, image string) {
+func setChainContainerImage(pod *corev1.Pod, image string) {
 	for i := range pod.Spec.Containers {
 		if pod.Spec.Containers[i].Name == mainContainer {
 			pod.Spec.Containers[i].Image = image
-			return
+			break
+		}
+	}
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == chainInitContainer {
+			pod.Spec.InitContainers[i].Image = image
+			break
 		}
 	}
 }

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -22,8 +22,9 @@ import (
 var bufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
 
 const (
-	healthCheckPort = healthcheck.Port
-	mainContainer   = "node"
+	healthCheckPort    = healthcheck.Port
+	mainContainer      = "node"
+	chainInitContainer = "chain-init"
 )
 
 // PodBuilder builds corev1.Pods
@@ -330,7 +331,7 @@ func initContainers(crd *cosmosv1.CosmosFullNode, moniker string) []corev1.Conta
 			WorkingDir:      workDir,
 		},
 		{
-			Name:    "chain-init",
+			Name:    chainInitContainer,
 			Image:   tpl.Image,
 			Command: []string{"sh"},
 			Args: []string{"-c",

--- a/internal/fullnode/pod_control_test.go
+++ b/internal/fullnode/pod_control_test.go
@@ -481,6 +481,7 @@ func recalculatePodRevision(pod *corev1.Pod, ordinal int) {
 func newPodWithNewImage(pod *corev1.Pod) {
 	pod.DeletionTimestamp = nil
 	pod.Spec.Containers[0].Image = "new-image"
+	pod.Spec.InitContainers[1].Image = "new-image"
 }
 
 func deletedPod(pod *corev1.Pod) {


### PR DESCRIPTION
If `spec.chain.versions` is populated, then `spec.podTemplate.image` is not required