### PR TITLE
Run trivy on image in PR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ steps.meta.outputs.tags[0] }}'
+          image-ref: '${{ fromJSON(steps.meta.outputs.tags)[0] }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags[0] }}'
+          image-ref: '${{ steps.meta.outputs.tags[0] }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}'
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tags[0] }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ fromJSON(steps.meta.outputs.tags)[0] }}'
+          image-ref: '${{ fromJSON(steps.meta.outputs.json).tags[0] }}'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true


### PR DESCRIPTION
Without the tag, it was running the image vulnerability scan on the latest image, which is only published on release tags.