### PR TITLE
PVC auto scale on a per ordinal basis

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -385,6 +385,11 @@ type AutoDataSource struct {
 	// If no VolumeSnapshots found, controller logs error and still creates PVC.
 	// +optional
 	VolumeSnapshotSelector map[string]string `json:"volumeSnapshotSelector"`
+
+	// If true, the volume snapshot selector will make sure the PVC
+	// is restored for the same instance as the VolumeSnapshot.
+	// This is useful if the VolumeSnapshots are local to the node, e.g. for topolvm.
+	MatchInstance bool `json:"matchInstance"`
 }
 
 // RolloutStrategy is an update strategy that can be shared between several Cosmos CRDs.

--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -387,7 +387,7 @@ type AutoDataSource struct {
 	VolumeSnapshotSelector map[string]string `json:"volumeSnapshotSelector"`
 
 	// If true, the volume snapshot selector will make sure the PVC
-	// is restored for the same instance as the VolumeSnapshot.
+	// is restored from a VolumeSnapshot on the same node.
 	// This is useful if the VolumeSnapshots are local to the node, e.g. for topolvm.
 	MatchInstance bool `json:"matchInstance"`
 }

--- a/api/v1/self_healing_types.go
+++ b/api/v1/self_healing_types.go
@@ -66,7 +66,7 @@ type HeightDriftMitigationSpec struct {
 type SelfHealingStatus struct {
 	// PVC auto-scaling status.
 	// +optional
-	PVCAutoScale *PVCAutoScaleStatus `json:"pvcAutoScale"`
+	PVCAutoScale map[string]*PVCAutoScaleStatus `json:"pvcAutoScaler"`
 }
 
 type PVCAutoScaleStatus struct {

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -679,8 +679,18 @@ func (in *SelfHealingStatus) DeepCopyInto(out *SelfHealingStatus) {
 	*out = *in
 	if in.PVCAutoScale != nil {
 		in, out := &in.PVCAutoScale, &out.PVCAutoScale
-		*out = new(PVCAutoScaleStatus)
-		(*in).DeepCopyInto(*out)
+		*out = make(map[string]*PVCAutoScaleStatus, len(*in))
+		for key, val := range *in {
+			var outVal *PVCAutoScaleStatus
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = new(PVCAutoScaleStatus)
+				(*in).DeepCopyInto(*out)
+			}
+			(*out)[key] = outVal
+		}
 	}
 }
 

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -388,8 +388,8 @@ spec:
                           properties:
                             matchInstance:
                               description: If true, the volume snapshot selector will
-                                make sure the PVC is restored for the same instance
-                                as the VolumeSnapshot. This is useful if the VolumeSnapshots
+                                make sure the PVC is restored from a VolumeSnapshot
+                                on the same node. This is useful if the VolumeSnapshots
                                 are local to the node, e.g. for topolvm.
                               type: boolean
                             volumeSnapshotSelector:
@@ -5824,9 +5824,9 @@ spec:
                     properties:
                       matchInstance:
                         description: If true, the volume snapshot selector will make
-                          sure the PVC is restored for the same instance as the VolumeSnapshot.
-                          This is useful if the VolumeSnapshots are local to the node,
-                          e.g. for topolvm.
+                          sure the PVC is restored from a VolumeSnapshot on the same
+                          node. This is useful if the VolumeSnapshots are local to
+                          the node, e.g. for topolvm.
                         type: boolean
                       volumeSnapshotSelector:
                         additionalProperties:

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -386,6 +386,12 @@ spec:
                             set; that field takes precedence. Configuring autoDataSource
                             may help boostrap new replicas more quickly.
                           properties:
+                            matchInstance:
+                              description: If true, the volume snapshot selector will
+                                make sure the PVC is restored for the same instance
+                                as the VolumeSnapshot. This is useful if the VolumeSnapshots
+                                are local to the node, e.g. for topolvm.
+                              type: boolean
                             volumeSnapshotSelector:
                               additionalProperties:
                                 type: string
@@ -397,6 +403,8 @@ spec:
                                 no VolumeSnapshots found, controller logs error and
                                 still creates PVC.
                               type: object
+                          required:
+                          - matchInstance
                           type: object
                         dataSource:
                           description: 'Can be used to specify either: * An existing
@@ -5814,6 +5822,12 @@ spec:
                       that field takes precedence. Configuring autoDataSource may
                       help boostrap new replicas more quickly.
                     properties:
+                      matchInstance:
+                        description: If true, the volume snapshot selector will make
+                          sure the PVC is restored for the same instance as the VolumeSnapshot.
+                          This is useful if the VolumeSnapshots are local to the node,
+                          e.g. for topolvm.
+                        type: boolean
                       volumeSnapshotSelector:
                         additionalProperties:
                           type: string
@@ -5824,6 +5838,8 @@ spec:
                           namespace as the CosmosFullNode. If no VolumeSnapshots found,
                           controller logs error and still creates PVC.
                         type: object
+                    required:
+                    - matchInstance
                     type: object
                   dataSource:
                     description: 'Can be used to specify either: * An existing VolumeSnapshot
@@ -5986,24 +6002,26 @@ spec:
               selfHealing:
                 description: Status set by the SelfHealing controller.
                 properties:
-                  pvcAutoScale:
+                  pvcAutoScaler:
+                    additionalProperties:
+                      properties:
+                        requestedAt:
+                          description: The timestamp the SelfHealing controller requested
+                            a PVC increase.
+                          format: date-time
+                          type: string
+                        requestedSize:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: The PVC size requested by the SelfHealing controller.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - requestedAt
+                      - requestedSize
+                      type: object
                     description: PVC auto-scaling status.
-                    properties:
-                      requestedAt:
-                        description: The timestamp the SelfHealing controller requested
-                          a PVC increase.
-                        format: date-time
-                        type: string
-                      requestedSize:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: The PVC size requested by the SelfHealing controller.
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                    required:
-                    - requestedAt
-                    - requestedSize
                     type: object
                 type: object
               status:

--- a/internal/fullnode/mock_test.go
+++ b/internal/fullnode/mock_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -58,6 +59,8 @@ func (m *mockClient[T]) Get(ctx context.Context, key client.ObjectKey, obj clien
 		*ref = m.Object.(corev1.PersistentVolumeClaim)
 	case *cosmosv1.CosmosFullNode:
 		*ref = m.Object.(cosmosv1.CosmosFullNode)
+	case *snapshotv1.VolumeSnapshot:
+		*ref = m.Object.(snapshotv1.VolumeSnapshot)
 	default:
 		panic(fmt.Errorf("unknown Object type: %T", m.ObjectList))
 	}

--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -37,6 +37,11 @@ func defaultCRD() cosmosv1.CosmosFullNode {
 					},
 				},
 			},
+			VolumeClaimTemplate: cosmosv1.PersistentVolumeClaimSpec{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("100Gi")},
+				},
+			},
 		},
 	}
 }

--- a/internal/fullnode/pvc_builder.go
+++ b/internal/fullnode/pvc_builder.go
@@ -76,7 +76,6 @@ func BuildPVCs(
 			Resources:        pvcResources(crd, name, dataSources[i], existingSize),
 			StorageClassName: ptr(tpl.StorageClassName),
 			VolumeMode:       valOrDefault(tpl.VolumeMode, ptr(corev1.PersistentVolumeFilesystem)),
-			DataSource:       dataSource,
 		}
 
 		preserveMergeInto(pvc.Labels, tpl.Metadata.Labels)

--- a/internal/fullnode/pvc_builder_test.go
+++ b/internal/fullnode/pvc_builder_test.go
@@ -22,12 +22,7 @@ func TestBuildPVCs(t *testing.T) {
 		crd := defaultCRD()
 		crd.Name = "juno"
 		crd.Spec.Replicas = 3
-		crd.Spec.VolumeClaimTemplate = cosmosv1.PersistentVolumeClaimSpec{
-			StorageClassName: "test-storage-class",
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("100G")},
-			},
-		}
+		crd.Spec.VolumeClaimTemplate.StorageClassName = "test-storage-class"
 
 		crd.Spec.InstanceOverrides = map[string]cosmosv1.InstanceOverridesSpec{
 			"juno-0": {},
@@ -80,20 +75,15 @@ func TestBuildPVCs(t *testing.T) {
 	t.Run("advanced configuration", func(t *testing.T) {
 		crd := defaultCRD()
 		crd.Spec.Replicas = 1
-		crd.Spec.VolumeClaimTemplate = cosmosv1.PersistentVolumeClaimSpec{
-			Metadata: cosmosv1.Metadata{
-				Labels:      map[string]string{"label": "value", "app.kubernetes.io/created-by": "should not see me"},
-				Annotations: map[string]string{"annot": "value"},
-			},
-			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
-			VolumeMode:  ptr(corev1.PersistentVolumeBlock),
-			DataSource: &corev1.TypedLocalObjectReference{
-				Kind: "TestKind",
-				Name: "source-name",
-			},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("100G")},
-			},
+		crd.Spec.VolumeClaimTemplate.Metadata = cosmosv1.Metadata{
+			Labels:      map[string]string{"label": "value", "app.kubernetes.io/created-by": "should not see me"},
+			Annotations: map[string]string{"annot": "value"},
+		}
+		crd.Spec.VolumeClaimTemplate.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+		crd.Spec.VolumeClaimTemplate.VolumeMode = ptr(corev1.PersistentVolumeBlock)
+		crd.Spec.VolumeClaimTemplate.DataSource = &corev1.TypedLocalObjectReference{
+			Kind: "TestKind",
+			Name: "source-name",
 		}
 
 		pvcs := BuildPVCs(&crd, map[int32]*dataSource{
@@ -170,11 +160,8 @@ func TestBuildPVCs(t *testing.T) {
 			} {
 				crd := defaultCRD()
 				crd.Spec.Replicas = 1
-				crd.Spec.VolumeClaimTemplate = cosmosv1.PersistentVolumeClaimSpec{
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(tt.SpecQuant)},
-					},
-				}
+				crd.Spec.VolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage] = resource.MustParse(tt.SpecQuant)
+
 				crd.Status.SelfHealing.PVCAutoScale = map[string]*cosmosv1.PVCAutoScaleStatus{
 					"pvc-osmosis-0": {
 						RequestedSize: resource.MustParse(tt.AutoScaleQuant),
@@ -197,11 +184,8 @@ func TestBuildPVCs(t *testing.T) {
 			} {
 				crd := defaultCRD()
 				crd.Spec.Replicas = 1
-				crd.Spec.VolumeClaimTemplate = cosmosv1.PersistentVolumeClaimSpec{
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(tt.SpecQuant)},
-					},
-				}
+				crd.Spec.VolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage] = resource.MustParse(tt.SpecQuant)
+
 				crd.Status.SelfHealing.PVCAutoScale = map[string]*cosmosv1.PVCAutoScaleStatus{
 					"pvc-osmosis-0": {
 						RequestedSize: resource.MustParse(tt.AutoScaleQuant),
@@ -224,11 +208,8 @@ func TestBuildPVCs(t *testing.T) {
 			} {
 				crd := defaultCRD()
 				crd.Spec.Replicas = 1
-				crd.Spec.VolumeClaimTemplate = cosmosv1.PersistentVolumeClaimSpec{
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(tt.SpecQuant)},
-					},
-				}
+				crd.Spec.VolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage] = resource.MustParse(tt.SpecQuant)
+
 				crd.Status.SelfHealing.PVCAutoScale = map[string]*cosmosv1.PVCAutoScaleStatus{
 					"pvc-osmosis-0": {
 						RequestedSize: resource.MustParse(tt.AutoScaleQuant),

--- a/internal/fullnode/pvc_control.go
+++ b/internal/fullnode/pvc_control.go
@@ -3,6 +3,7 @@ package fullnode
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	"github.com/samber/lo"
@@ -10,6 +11,7 @@ import (
 	"github.com/strangelove-ventures/cosmos-operator/internal/diff"
 	"github.com/strangelove-ventures/cosmos-operator/internal/kube"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,9 +32,13 @@ func NewPVCControl(client Client) PVCControl {
 	}
 }
 
+type PVCStatusChanges struct {
+	Deleted []string
+}
+
 // Reconcile is the control loop for PVCs. The bool return value, if true, indicates the controller should requeue
 // the request.
-func (control PVCControl) Reconcile(ctx context.Context, reporter kube.Reporter, crd *cosmosv1.CosmosFullNode) (bool, kube.ReconcileError) {
+func (control PVCControl) Reconcile(ctx context.Context, reporter kube.Reporter, crd *cosmosv1.CosmosFullNode, pvcStatusChanges *PVCStatusChanges) (bool, kube.ReconcileError) {
 	// Find any existing pvcs for this CRD.
 	var vols corev1.PersistentVolumeClaimList
 	if err := control.client.List(ctx, &vols,
@@ -42,35 +48,57 @@ func (control PVCControl) Reconcile(ctx context.Context, reporter kube.Reporter,
 		return false, kube.TransientError(fmt.Errorf("list existing pvcs: %w", err))
 	}
 
-	var (
-		currentPVCs = ptrSlice(vols.Items)
-		wantPVCs    = BuildPVCs(crd)
-		diffed      = diff.New(currentPVCs, wantPVCs)
-	)
+	var currentPVCs = ptrSlice(vols.Items)
 
-	var dataSource *corev1.TypedLocalObjectReference
-	if len(diffed.Creates()) > 0 {
-		dataSource = control.findDataSource(ctx, reporter, crd)
+	dataSources := make(map[int32]*dataSource)
+	if len(currentPVCs) < int(crd.Spec.Replicas) {
+		for i := int32(0); i < crd.Spec.Replicas; i++ {
+			name := pvcName(crd, i)
+			found := false
+			for _, pvc := range currentPVCs {
+				if pvc.Name == name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				dataSources[i] = control.findDataSource(ctx, reporter, crd, i)
+			}
+		}
 	}
 
+	var (
+		wantPVCs = BuildPVCs(crd, dataSources)
+		diffed   = diff.New(currentPVCs, wantPVCs)
+	)
+
 	for _, pvc := range diffed.Creates() {
-		pvc.Spec.DataSource = dataSource
-		reporter.Info("Creating pvc", "pvc", pvc.Name)
+		ordinal, err := strconv.ParseInt(pvc.Annotations[kube.OrdinalAnnotation], 10, 32)
+		if err != nil {
+			return true, kube.TransientError(fmt.Errorf("parse ordinal from pvc %s: %w", pvc.Name, err))
+		}
+		dataSource, ok := dataSources[int32(ordinal)]
+		if ok && dataSource != nil {
+			pvc.Spec.DataSource = dataSource.ref
+		}
+		reporter.Info("Creating pvc", "name", pvc.Name)
 		if err := ctrl.SetControllerReference(crd, pvc, control.client.Scheme()); err != nil {
 			return true, kube.TransientError(fmt.Errorf("set controller reference on pvc %q: %w", pvc.Name, err))
 		}
 		if err := control.client.Create(ctx, pvc); kube.IgnoreAlreadyExists(err) != nil {
 			return true, kube.TransientError(fmt.Errorf("create pvc %q: %w", pvc.Name, err))
 		}
+		pvcStatusChanges.Deleted = append(pvcStatusChanges.Deleted, pvc.Name)
 	}
 
 	var deletes int
 	if !control.shouldRetain(crd) {
 		for _, pvc := range diffed.Deletes() {
-			reporter.Info("Deleting pvc", "pvc", pvc.Name)
+			reporter.Info("Deleting pvc", "name", pvc.Name)
 			if err := control.client.Delete(ctx, pvc, client.PropagationPolicy(metav1.DeletePropagationForeground)); client.IgnoreNotFound(err) != nil {
 				return true, kube.TransientError(fmt.Errorf("delete pvc %q: %w", pvc.Name, err))
 			}
+			pvcStatusChanges.Deleted = append(pvcStatusChanges.Deleted, pvc.Name)
 		}
 		deletes = len(diffed.Deletes())
 	}
@@ -92,7 +120,7 @@ func (control PVCControl) Reconcile(ctx context.Context, reporter kube.Reporter,
 
 	// PVCs have many immutable fields, so only update the storage size.
 	for _, pvc := range diffed.Updates() {
-		reporter.Info("Patching pvc", "pvc", pvc.Name)
+		reporter.Info("Patching pvc", "name", pvc.Name)
 		patch := corev1.PersistentVolumeClaim{
 			ObjectMeta: pvc.ObjectMeta,
 			TypeMeta:   pvc.TypeMeta,
@@ -101,7 +129,7 @@ func (control PVCControl) Reconcile(ctx context.Context, reporter kube.Reporter,
 			},
 		}
 		if err := control.client.Patch(ctx, &patch, client.Merge); err != nil {
-			reporter.Error(err, "PVC patch failed", "pvc", pvc.Name)
+			reporter.Error(err, "PVC patch failed", "name", pvc.Name)
 			reporter.RecordError("PVCPatchFailed", err)
 			continue
 		}
@@ -117,17 +145,69 @@ func (control PVCControl) shouldRetain(crd *cosmosv1.CosmosFullNode) bool {
 	return false
 }
 
-func (control PVCControl) findDataSource(ctx context.Context, reporter kube.Reporter, crd *cosmosv1.CosmosFullNode) *corev1.TypedLocalObjectReference {
-	if ds := crd.Spec.VolumeClaimTemplate.DataSource; ds != nil {
-		return ds
+type dataSource struct {
+	ref *corev1.TypedLocalObjectReference
+
+	size resource.Quantity
+}
+
+func (control PVCControl) findDataSource(ctx context.Context, reporter kube.Reporter, crd *cosmosv1.CosmosFullNode, ordinal int32) *dataSource {
+	if override, ok := crd.Spec.InstanceOverrides[instanceName(crd, ordinal)]; ok {
+		if overrideTpl := override.VolumeClaimTemplate; overrideTpl != nil {
+			return control.findDataSourceWithPvcSpec(ctx, reporter, crd, *overrideTpl, ordinal)
+		}
 	}
-	spec := crd.Spec.VolumeClaimTemplate.AutoDataSource
+
+	return control.findDataSourceWithPvcSpec(ctx, reporter, crd, crd.Spec.VolumeClaimTemplate, ordinal)
+}
+
+func (control PVCControl) findDataSourceWithPvcSpec(
+	ctx context.Context,
+	reporter kube.Reporter,
+	crd *cosmosv1.CosmosFullNode,
+	pvcSpec cosmosv1.PersistentVolumeClaimSpec,
+	ordinal int32,
+) *dataSource {
+	if ds := pvcSpec.DataSource; ds != nil {
+		if ds.Kind == "VolumeSnapshot" && ds.APIGroup != nil && *ds.APIGroup == "snapshot.storage.k8s.io" {
+			var vs snapshotv1.VolumeSnapshot
+			if err := control.client.Get(ctx, client.ObjectKey{Namespace: crd.Namespace, Name: ds.Name}, &vs); err != nil {
+				reporter.Error(err, "Failed to get VolumeSnapshot for DataSource")
+				reporter.RecordError("DataSourceGetSnapshot", err)
+				return nil
+			}
+			return &dataSource{
+				ref:  ds,
+				size: *vs.Status.RestoreSize,
+			}
+		} else if ds.Kind == "PersistentVolumeClaim" && (ds.APIGroup == nil || *ds.APIGroup == "") {
+			var pvc corev1.PersistentVolumeClaim
+			if err := control.client.Get(ctx, client.ObjectKey{Namespace: crd.Namespace, Name: ds.Name}, &pvc); err != nil {
+				reporter.Error(err, "Failed to get PersistentVolumeClaim for DataSource")
+				reporter.RecordError("DataSourceGetPVC", err)
+				return nil
+			}
+			return &dataSource{
+				ref:  ds,
+				size: pvc.Status.Capacity["storage"],
+			}
+		} else {
+			err := fmt.Errorf("unsupported DataSource %s", ds.Kind)
+			reporter.Error(err, "Unsupported DataSource")
+			reporter.RecordError("DataSourceUnsupported", err)
+			return nil
+		}
+	}
+	spec := pvcSpec.AutoDataSource
 	if spec == nil {
 		return nil
 	}
 	selector := spec.VolumeSnapshotSelector
 	if len(selector) == 0 {
 		return nil
+	}
+	if spec.MatchInstance {
+		selector[kube.InstanceLabel] = instanceName(crd, ordinal)
 	}
 	found, err := control.recentVolumeSnapshot(ctx, control.client, crd.Namespace, selector)
 	if err != nil {
@@ -137,9 +217,12 @@ func (control PVCControl) findDataSource(ctx context.Context, reporter kube.Repo
 	}
 
 	reporter.RecordInfo("AutoDataSource", "Using recent VolumeSnapshot for PVC data source")
-	return &corev1.TypedLocalObjectReference{
-		APIGroup: ptr("snapshot.storage.k8s.io"),
-		Kind:     "VolumeSnapshot",
-		Name:     found.Name,
+	return &dataSource{
+		ref: &corev1.TypedLocalObjectReference{
+			APIGroup: ptr("snapshot.storage.k8s.io"),
+			Kind:     "VolumeSnapshot",
+			Name:     found.Name,
+		},
+		size: *found.Status.RestoreSize,
 	}
 }

--- a/internal/fullnode/pvc_control.go
+++ b/internal/fullnode/pvc_control.go
@@ -68,7 +68,7 @@ func (control PVCControl) Reconcile(ctx context.Context, reporter kube.Reporter,
 	}
 
 	var (
-		wantPVCs = BuildPVCs(crd, dataSources)
+		wantPVCs = BuildPVCs(crd, dataSources, currentPVCs)
 		diffed   = diff.New(currentPVCs, wantPVCs)
 	)
 

--- a/internal/fullnode/pvc_control_test.go
+++ b/internal/fullnode/pvc_control_test.go
@@ -40,7 +40,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		crd.Name = "hub"
 		crd.Namespace = namespace
 		crd.Spec.Replicas = 1
-		existing := diff.New(nil, BuildPVCs(&crd, map[int32]*dataSource{})).Creates()[0]
+		existing := diff.New(nil, BuildPVCs(&crd, map[int32]*dataSource{}, nil)).Creates()[0]
 		existing.Status.Phase = corev1.ClaimBound
 
 		var mClient mockPVCClient
@@ -73,7 +73,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		crd.Namespace = namespace
 		crd.Name = "hub"
 		crd.Spec.Replicas = 1
-		existing := BuildPVCs(&crd, map[int32]*dataSource{})[0].Object()
+		existing := BuildPVCs(&crd, map[int32]*dataSource{}, nil)[0].Object()
 
 		var mClient mockPVCClient
 		mClient.ObjectList = corev1.PersistentVolumeClaimList{
@@ -230,7 +230,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		crd.Spec.Replicas = 1
 
 		var mClient mockPVCClient
-		existing := BuildPVCs(&crd, map[int32]*dataSource{})[0].Object()
+		existing := BuildPVCs(&crd, map[int32]*dataSource{}, nil)[0].Object()
 		existing.Status.Phase = corev1.ClaimBound
 		mClient.ObjectList = corev1.PersistentVolumeClaimList{
 			Items: []corev1.PersistentVolumeClaim{*existing},
@@ -266,7 +266,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		crd.Namespace = namespace
 		crd.Spec.Replicas = 1
 
-		existing := BuildPVCs(&crd, map[int32]*dataSource{})[0].Object()
+		existing := BuildPVCs(&crd, map[int32]*dataSource{}, nil)[0].Object()
 		existing.Status.Phase = corev1.ClaimPending
 		var mClient mockPVCClient
 		mClient.ObjectList = corev1.PersistentVolumeClaimList{

--- a/internal/fullnode/pvc_control_test.go
+++ b/internal/fullnode/pvc_control_test.go
@@ -111,9 +111,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		crd.Spec.VolumeClaimTemplate.AutoDataSource = &cosmosv1.AutoDataSource{
 			VolumeSnapshotSelector: map[string]string{"label": "vol-snapshot"},
 		}
-		crd.Spec.VolumeClaimTemplate.Resources = corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{"storage": resource.MustParse("100Gi")},
-		}
+
 		var volCallCount int
 		control.recentVolumeSnapshot = func(ctx context.Context, lister kube.Lister, namespace string, selector map[string]string) (*snapshotv1.VolumeSnapshot, error) {
 			require.NotNil(t, ctx)
@@ -165,9 +163,6 @@ func TestPVCControl_Reconcile(t *testing.T) {
 			VolumeSnapshotSelector: map[string]string{"label": "vol-snapshot"},
 		}
 		crd.Spec.VolumeClaimTemplate.DataSource = crdDataSource
-		crd.Spec.VolumeClaimTemplate.Resources = corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{"storage": resource.MustParse("100Gi")},
-		}
 
 		control.recentVolumeSnapshot = func(ctx context.Context, lister kube.Lister, namespace string, selector map[string]string) (*snapshotv1.VolumeSnapshot, error) {
 			panic("should not be called")
@@ -238,9 +233,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 
 		// Cause a change
 		crd.Spec.VolumeClaimTemplate.VolumeMode = ptr(corev1.PersistentVolumeMode("should not be in the patch"))
-		crd.Spec.VolumeClaimTemplate.Resources = corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{"memory": resource.MustParse("1Gi")},
-		}
+		crd.Spec.VolumeClaimTemplate.Resources.Requests["memory"] = resource.MustParse("1Gi")
 
 		control := testPVCControl(&mClient)
 		requeue, rerr := control.Reconcile(ctx, nopReporter, &crd, &PVCStatusChanges{})
@@ -274,9 +267,8 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		}
 
 		// Cause a change
-		crd.Spec.VolumeClaimTemplate.Resources = corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Ti")},
-		}
+		crd.Spec.VolumeClaimTemplate.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("1Ti")
+
 		control := testPVCControl(&mClient)
 		requeue, rerr := control.Reconcile(ctx, nopReporter, &crd, &PVCStatusChanges{})
 		require.NoError(t, rerr)

--- a/internal/fullnode/pvc_control_test.go
+++ b/internal/fullnode/pvc_control_test.go
@@ -40,7 +40,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		crd.Name = "hub"
 		crd.Namespace = namespace
 		crd.Spec.Replicas = 1
-		existing := diff.New(nil, BuildPVCs(&crd)).Creates()[0]
+		existing := diff.New(nil, BuildPVCs(&crd, map[int32]*dataSource{})).Creates()[0]
 		existing.Status.Phase = corev1.ClaimBound
 
 		var mClient mockPVCClient
@@ -52,7 +52,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 
 		control := testPVCControl(&mClient)
 
-		requeue, err := control.Reconcile(ctx, nopReporter, &crd)
+		requeue, err := control.Reconcile(ctx, nopReporter, &crd, &PVCStatusChanges{})
 		require.NoError(t, err)
 		require.False(t, requeue)
 
@@ -73,7 +73,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		crd.Namespace = namespace
 		crd.Name = "hub"
 		crd.Spec.Replicas = 1
-		existing := BuildPVCs(&crd)[0].Object()
+		existing := BuildPVCs(&crd, map[int32]*dataSource{})[0].Object()
 
 		var mClient mockPVCClient
 		mClient.ObjectList = corev1.PersistentVolumeClaimList{
@@ -86,7 +86,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 
 		crd.Spec.Replicas = 4
 		control := testPVCControl(&mClient)
-		requeue, err := control.Reconcile(ctx, nopReporter, &crd)
+		requeue, err := control.Reconcile(ctx, nopReporter, &crd, &PVCStatusChanges{})
 		require.NoError(t, err)
 		require.True(t, requeue)
 
@@ -111,6 +111,9 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		crd.Spec.VolumeClaimTemplate.AutoDataSource = &cosmosv1.AutoDataSource{
 			VolumeSnapshotSelector: map[string]string{"label": "vol-snapshot"},
 		}
+		crd.Spec.VolumeClaimTemplate.Resources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{"storage": resource.MustParse("100Gi")},
+		}
 		var volCallCount int
 		control.recentVolumeSnapshot = func(ctx context.Context, lister kube.Lister, namespace string, selector map[string]string) (*snapshotv1.VolumeSnapshot, error) {
 			require.NotNil(t, ctx)
@@ -119,14 +122,18 @@ func TestPVCControl_Reconcile(t *testing.T) {
 			require.Equal(t, map[string]string{"label": "vol-snapshot"}, selector)
 			var stub snapshotv1.VolumeSnapshot
 			stub.Name = "found-snapshot"
+			stub.Status = &snapshotv1.VolumeSnapshotStatus{
+				ReadyToUse:  ptr(true),
+				RestoreSize: ptr(resource.MustParse("100Gi")),
+			}
 			volCallCount++
 			return &stub, nil
 		}
-		requeue, err := control.Reconcile(ctx, nopReporter, &crd)
+		requeue, err := control.Reconcile(ctx, nopReporter, &crd, &PVCStatusChanges{})
 		require.NoError(t, err)
 		require.True(t, requeue)
 
-		require.Equal(t, 1, volCallCount)
+		require.Equal(t, 3, volCallCount)
 		require.Equal(t, 3, mClient.CreateCount)
 
 		want := corev1.TypedLocalObjectReference{
@@ -158,11 +165,26 @@ func TestPVCControl_Reconcile(t *testing.T) {
 			VolumeSnapshotSelector: map[string]string{"label": "vol-snapshot"},
 		}
 		crd.Spec.VolumeClaimTemplate.DataSource = crdDataSource
+		crd.Spec.VolumeClaimTemplate.Resources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{"storage": resource.MustParse("100Gi")},
+		}
 
 		control.recentVolumeSnapshot = func(ctx context.Context, lister kube.Lister, namespace string, selector map[string]string) (*snapshotv1.VolumeSnapshot, error) {
 			panic("should not be called")
 		}
-		requeue, err := control.Reconcile(ctx, nopReporter, &crd)
+
+		mClient.Object = snapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "user-set-snapshot",
+				Namespace: namespace,
+			},
+			Status: &snapshotv1.VolumeSnapshotStatus{
+				ReadyToUse:  ptr(true),
+				RestoreSize: ptr(resource.MustParse("100Gi")),
+			},
+		}
+
+		requeue, err := control.Reconcile(ctx, nopReporter, &crd, &PVCStatusChanges{})
 		require.NoError(t, err)
 		require.True(t, requeue)
 
@@ -191,7 +213,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 			volCallCount++
 			return nil, errors.New("boom")
 		}
-		requeue, err := control.Reconcile(ctx, nopReporter, &crd)
+		requeue, err := control.Reconcile(ctx, nopReporter, &crd, &PVCStatusChanges{})
 		require.NoError(t, err)
 		require.True(t, requeue)
 
@@ -208,7 +230,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		crd.Spec.Replicas = 1
 
 		var mClient mockPVCClient
-		existing := BuildPVCs(&crd)[0].Object()
+		existing := BuildPVCs(&crd, map[int32]*dataSource{})[0].Object()
 		existing.Status.Phase = corev1.ClaimBound
 		mClient.ObjectList = corev1.PersistentVolumeClaimList{
 			Items: []corev1.PersistentVolumeClaim{*existing},
@@ -221,7 +243,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		}
 
 		control := testPVCControl(&mClient)
-		requeue, rerr := control.Reconcile(ctx, nopReporter, &crd)
+		requeue, rerr := control.Reconcile(ctx, nopReporter, &crd, &PVCStatusChanges{})
 		require.NoError(t, rerr)
 		require.False(t, requeue)
 
@@ -244,7 +266,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		crd.Namespace = namespace
 		crd.Spec.Replicas = 1
 
-		existing := BuildPVCs(&crd)[0].Object()
+		existing := BuildPVCs(&crd, map[int32]*dataSource{})[0].Object()
 		existing.Status.Phase = corev1.ClaimPending
 		var mClient mockPVCClient
 		mClient.ObjectList = corev1.PersistentVolumeClaimList{
@@ -256,7 +278,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 			Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Ti")},
 		}
 		control := testPVCControl(&mClient)
-		requeue, rerr := control.Reconcile(ctx, nopReporter, &crd)
+		requeue, rerr := control.Reconcile(ctx, nopReporter, &crd, &PVCStatusChanges{})
 		require.NoError(t, rerr)
 		require.True(t, requeue)
 
@@ -278,7 +300,7 @@ func TestPVCControl_Reconcile(t *testing.T) {
 		}
 
 		control := testPVCControl(&mClient)
-		requeue, err := control.Reconcile(ctx, nopReporter, &crd)
+		requeue, err := control.Reconcile(ctx, nopReporter, &crd, &PVCStatusChanges{})
 		require.NoError(t, err)
 		require.False(t, requeue)
 


### PR DESCRIPTION
Main motivation: 
- minimize created PVC size and expand only as needed on a per-PVC basis. Previously, it was always creating new PVCs with the latest auto scaled size, which meant that PVCs could not shrink on re-creation without re-creating the entire CosmosFullNode resource.
- Allow autoDataSource to work with snapshots that are node-local

Changes:
- New PVCs will not use the `status.selfHealing` size, but rather the maximum of: {  `spec.volumeClaimTemplate.resources.storage`,  `spec.instanceOverrides[instanceName].volumeClaimTemplate.resources.storage`, or data source size, if a data source is configured either explicitly or via `autoDataSource` }
- `status.selfHealing` is now maintained on a per-instance basis, so that storage expansion is minimized. Pods can have different storage sizes based on their needs.
- Allow `autoDataSource` to work with snapshots for same instance only with additional `matchInstance: true`

