### PR TITLE
version check patch

### DIFF
--- a/cmd/versioncheck.go
+++ b/cmd/versioncheck.go
@@ -162,17 +162,8 @@ func checkVersion(
 		}
 	}
 
-	patch := crd.DeepCopy()
-	if patch.Status.Height == nil {
-		patch.Status.Height = make(map[string]uint64)
-	}
-
-	patch.Status.Height[thisPod.Name] = uint64(height)
-
-	if err := kClient.Status().Patch(
-		ctx, patch, client.StrategicMergeFrom(crd.DeepCopy()),
-	); err != nil {
-		return fmt.Errorf("failed to patch status: %w", err)
+	if err := patchStatusHeightIfNecessary(ctx, kClient, crd, thisPod.Name, uint64(height)); err != nil {
+		return err
 	}
 
 	var image string
@@ -189,6 +180,35 @@ func checkVersion(
 	}
 
 	fmt.Fprintf(writer, "Verified correct image for height %d: %s\n", height, image)
+
+	return nil
+}
+
+func patchStatusHeightIfNecessary(
+	ctx context.Context,
+	kClient client.Client,
+	crd *cosmosv1.CosmosFullNode,
+	instanceName string,
+	height uint64,
+) error {
+	if crd.Status.Height != nil {
+		if h, ok := crd.Status.Height[instanceName]; ok && h == height {
+			// Status is up to date already.
+			return nil
+		}
+	}
+
+	patch := crd.DeepCopy()
+	if patch.Status.Height == nil {
+		patch.Status.Height = make(map[string]uint64)
+	}
+	patch.Status.Height[instanceName] = height
+
+	if err := kClient.Status().Patch(
+		ctx, patch, client.MergeFrom(crd.DeepCopy()),
+	); err != nil {
+		return fmt.Errorf("failed to patch status: %w", err)
+	}
 
 	return nil
 }

--- a/cmd/versioncheck.go
+++ b/cmd/versioncheck.go
@@ -162,14 +162,15 @@ func checkVersion(
 		}
 	}
 
-	if crd.Status.Height == nil {
-		crd.Status.Height = make(map[string]uint64)
+	patch := crd.DeepCopy()
+	if patch.Status.Height == nil {
+		patch.Status.Height = make(map[string]uint64)
 	}
 
-	crd.Status.Height[thisPod.Name] = uint64(height)
+	patch.Status.Height[thisPod.Name] = uint64(height)
 
-	if err := kClient.Status().Update(
-		ctx, crd,
+	if err := kClient.Status().Patch(
+		ctx, patch, client.StrategicMergeFrom(crd.DeepCopy()),
 	); err != nil {
 		return fmt.Errorf("failed to patch status: %w", err)
 	}

--- a/internal/fullnode/rbac_builder.go
+++ b/internal/fullnode/rbac_builder.go
@@ -72,7 +72,7 @@ func BuildRoles(crd *cosmosv1.CosmosFullNode) []diff.Resource[*rbacv1.Role] {
 			{
 				APIGroups: []string{"cosmos.strange.love"},
 				Resources: []string{"cosmosfullnodes/status"},
-				Verbs:     []string{"update"},
+				Verbs:     []string{"patch"},
 			},
 		},
 	}

--- a/internal/fullnode/rbac_builder_test.go
+++ b/internal/fullnode/rbac_builder_test.go
@@ -71,7 +71,7 @@ func TestBuildRBAC(t *testing.T) {
 			{
 				APIGroups: []string{"cosmos.strange.love"},
 				Resources: []string{"cosmosfullnodes/status"},
-				Verbs:     []string{"update"},
+				Verbs:     []string{"patch"},
 			},
 		}, role.Rules)
 


### PR DESCRIPTION
The `version-check` initContainer and `version-check-term` container should use the `Patch` operation instead of `Update` to avoid race conditions that can result in errors logs such as:

```
failed to patch status: Operation cannot be fulfillfed on cosmosfullnodes.cosmos.strange.love: the object has been modified
```

This is only seen intermittently, and the instance will automatically recover on the next restart.

Since the version check is a synchronous operation per instance, we don't need to worry about multiple concurrent writers to the status.height of the specific instance. The RPC status.height updates will only occur after this when the node is started.