### PR TITLE
Support extra init args

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -543,6 +543,10 @@ type ChainSpec struct {
 	// +optional
 	Versions []ChainVersion `json:"versions"`
 
+	// Additional arguments to pass to the chain init command.
+	// +optional
+	AdditionalInitArgs []string `json:"additionalInitArgs"`
+
 	// Additional arguments to pass to the chain start command.
 	// +optional
 	AdditionalStartArgs []string `json:"additionalStartArgs"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -109,6 +109,11 @@ func (in *ChainSpec) DeepCopyInto(out *ChainSpec) {
 		*out = make([]ChainVersion, len(*in))
 		copy(*out, *in)
 	}
+	if in.AdditionalInitArgs != nil {
+		in, out := &in.AdditionalInitArgs, &out.AdditionalInitArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.AdditionalStartArgs != nil {
 		in, out := &in.AdditionalStartArgs, &out.AdditionalStartArgs
 		*out = make([]string, len(*in))

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -45,6 +45,11 @@ spec:
               chain:
                 description: Blockchain-specific configuration.
                 properties:
+                  additionalInitArgs:
+                    description: Additional arguments to pass to the chain init command.
+                    items:
+                      type: string
+                    type: array
                   additionalStartArgs:
                     description: Additional arguments to pass to the chain start command.
                     items:

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -319,7 +319,10 @@ func initContainers(crd *cosmosv1.CosmosFullNode, moniker string) []corev1.Conta
 	addrbookCmd, addrbookArgs := DownloadAddrbookCommand(crd.Spec.ChainSpec)
 	env := envVars(crd)
 
-	initCmd := fmt.Sprintf("%s init %s --chain-id %s", binary, moniker, crd.Spec.ChainSpec.ChainID)
+	initCmd := fmt.Sprintf("%s --chain-id %s init %s", binary, crd.Spec.ChainSpec.ChainID, moniker)
+	if len(crd.Spec.ChainSpec.AdditionalInitArgs) > 0 {
+		initCmd += " " + strings.Join(crd.Spec.ChainSpec.AdditionalInitArgs, " ")
+	}
 	required := []corev1.Container{
 		{
 			Name:            "clean-init",

--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -287,8 +287,8 @@ func TestPodBuilder(t *testing.T) {
 		require.Contains(t, freshCont.Args[1], `rm -rf "$HOME/.tmp/*"`)
 
 		initCont := pod.Spec.InitContainers[1]
-		require.Contains(t, initCont.Args[1], `osmosisd init osmosis-6 --chain-id osmosis-123 --home "$CHAIN_HOME"`)
-		require.Contains(t, initCont.Args[1], `osmosisd init osmosis-6 --chain-id osmosis-123 --home "$HOME/.tmp"`)
+		require.Contains(t, initCont.Args[1], `osmosisd --chain-id osmosis-123 init osmosis-6 --home "$CHAIN_HOME"`)
+		require.Contains(t, initCont.Args[1], `osmosisd --chain-id osmosis-123 init osmosis-6 --home "$HOME/.tmp"`)
 
 		mergeConfig1 := pod.Spec.InitContainers[3]
 		// The order of config-merge arguments is important. Rightmost takes precedence.


### PR DESCRIPTION
Allow providing additional args to the chain init command using `spec.chain.additionalInitArgs []string`