### PR TITLE
Write both sets of properties

### DIFF
--- a/internal/fullnode/testdata/comet.toml
+++ b/internal/fullnode/testdata/comet.toml
@@ -1,19 +1,29 @@
 log_format = "json"
+log-format = "json"
 log_level = "debug"
+log-level = "debug"
 priv_validator_laddr = ""
+priv-validator-laddr = ""
 
 [p2p]
 laddr = "tcp://0.0.0.0:26656"
 persistent_peers = "peer1@1.2.2.2:789,peer2@2.2.2.2:789,peer3@3.2.2.2:789"
+persistent-peers = "peer1@1.2.2.2:789,peer2@2.2.2.2:789,peer3@3.2.2.2:789"
 seeds = "seed1@1.1.1.1:456,seed2@1.1.1.1:456"
 max_num_inbound_peers = 5
+max-num-inbound_peers = 5
 max_num_outbound_peers = 15
+max-num-outbound-peers = 15
 
 [rpc]
 laddr = "tcp://0.0.0.0:26657"
 cors_allowed_origins = ["*"]
+cors-allowed-origins = ["*"]
 
 [tx_index]
+indexer = "kv"
+
+[tx-index]
 indexer = "kv"
 
 [instrumentation]

--- a/internal/fullnode/testdata/comet_defaults.toml
+++ b/internal/fullnode/testdata/comet_defaults.toml
@@ -1,19 +1,29 @@
 log_format = "plain"
+log-format = "plain"
 log_level = "info"
+log-level = "info"
 priv_validator_laddr = ""
+priv-validator-laddr = ""
 
 [p2p]
 laddr = "tcp://0.0.0.0:26656"
 persistent_peers = "peer1@1.2.2.2:789,peer2@2.2.2.2:789,peer3@3.2.2.2:789"
+persistent-peers = "peer1@1.2.2.2:789,peer2@2.2.2.2:789,peer3@3.2.2.2:789"
 seeds = "seed1@1.1.1.1:456,seed2@1.1.1.1:456"
 max_num_inbound_peers = 20
+max-num-inbound_peers = 20
 max_num_outbound_peers = 20
+max-num-outbound_peers = 20
 
 [rpc]
 laddr = "tcp://0.0.0.0:26657"
 cors_allowed_origins = []
+cors-allowed-origins = []
 
 [tx_index]
+indexer = "kv"
+
+[tx-index]
 indexer = "kv"
 
 [instrumentation]

--- a/internal/fullnode/testdata/comet_overrides.toml
+++ b/internal/fullnode/testdata/comet_overrides.toml
@@ -1,23 +1,32 @@
 log_format = "json"
+log-format = "json"
 log_level = "info"
+log-level = "info"
 priv_validator_laddr = ""
+priv-validator-laddr = ""
 new_base = "new base value"
 
 [p2p]
 external_address = "override.example.com"
 laddr = "tcp://0.0.0.0:26656"
 persistent_peers = "peer1@1.2.2.2:789,peer2@2.2.2.2:789,peer3@3.2.2.2:789"
+persistent-peers = "peer1@1.2.2.2:789,peer2@2.2.2.2:789,peer3@3.2.2.2:789"
 seeds = "override@seed"
 max_num_inbound_peers = 20
+max-num-inbound-peers = 20
 max_num_outbound_peers = 20
+max-num-outbound_peers = 20
 new_field = "p2p"
 
 [rpc]
 laddr = "tcp://0.0.0.0:26657"
 cors_allowed_origins = ["override"]
+cors-allowed-origins = ["override"]
 
 [tx_index]
+indexer = "null"
 
+[tx-index]
 indexer = "null"
 
 [new_section]


### PR DESCRIPTION
Make config.toml properties compatible with tendermint/comet versions which use either `-` or `_` for property word separation.