### PR TITLE
fix(kube): cleanup config manifests

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -7,19 +7,19 @@ resources:
 - bases/cosmos.strange.love_scheduledvolumesnapshots.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_cosmosfullnodes.yaml
-#- patches/webhook_in_statefuljobs.yaml
-#- patches/webhook_in_scheduledvolumesnapshots.yaml
+#- path: patches/webhook_in_cosmosfullnodes.yaml
+#- path: patches/webhook_in_statefuljobs.yaml
+#- path: patches/webhook_in_scheduledvolumesnapshots.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_cosmosfullnodes.yaml
-#- patches/cainjection_in_statefuljobs.yaml
-#- patches/cainjection_in_scheduledvolumesnapshots.yaml
+#- path: patches/cainjection_in_cosmosfullnodes.yaml
+#- path: patches/cainjection_in_statefuljobs.yaml
+#- path: patches/cainjection_in_scheduledvolumesnapshots.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/crd/patches/webhook_in_cosmosfullnodes.yaml
+++ b/config/crd/patches/webhook_in_cosmosfullnodes.yaml
@@ -9,7 +9,6 @@ spec:
     webhook:
       clientConfig:
         service:
-          namespace: system
           name: webhook-service
           path: /convert
       conversionReviewVersions:

--- a/config/crd/patches/webhook_in_hostedsnapshots.yaml
+++ b/config/crd/patches/webhook_in_hostedsnapshots.yaml
@@ -9,7 +9,6 @@ spec:
     webhook:
       clientConfig:
         service:
-          namespace: system
           name: webhook-service
           path: /convert
       conversionReviewVersions:

--- a/config/crd/patches/webhook_in_scheduledvolumesnapshots.yaml
+++ b/config/crd/patches/webhook_in_scheduledvolumesnapshots.yaml
@@ -9,7 +9,6 @@ spec:
     webhook:
       clientConfig:
         service:
-          namespace: system
           name: webhook-service
           path: /convert
       conversionReviewVersions:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -24,24 +24,24 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+- path: manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
-#- manager_config_patch.yaml
+#- path: manager_config_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+#- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+#- path: webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -4,7 +4,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
-  namespace: system
 spec:
   template:
     spec:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
-  namespace: system
 spec:
   template:
     spec:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,13 +3,12 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: system
+  name: cosmos-operator-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
-  namespace: system
   labels:
     control-plane: controller-manager
 spec:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     control-plane: controller-manager
   name: controller-manager-metrics-monitor
-  namespace: system
 spec:
   endpoints:
     - path: /metrics

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     control-plane: controller-manager
   name: controller-manager-metrics-service
-  namespace: system
 spec:
   ports:
   - name: https

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: controller-manager
-  namespace: system


### PR DESCRIPTION
- Use patches instead of deprecated patchesStrategicMerge
- Remove hardcoded namespace from resources This is automatically added by the config kustomization. Having it requires overlays to specify `namespace: system` or others in their `patches: target` which is confusing.

## Tests

Created a dummy config kustomization and tested that allow following scenarios result in the same kustomize build

- Specifying the namespace: `example-ns` 
- Removing the namespace (results in exactly the same manifests, but with `cosmos-operator-system` as namespace ofc)
- Removing the `target` from the patch


```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

namespace: example-ns

resources:
  - /path/to/cosmos-operator/config/default

patches:
  - target:
     kind: Deployment
     name: controller-manager
    patch: |-
      apiVersion: apps/v1
      kind: Deployment
      metadata:
        name: controller-manager
      spec:
        template:
          spec:
            containers:
            - name: manager
              resources:
                limits:
                  memory: 128Mi
```