### PR TITLE
docs: fix typo in quick_start.md

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -4,7 +4,7 @@ This quick start guide creates a CosmosFullNode that runs as an RPC node for the
 
 ### Prerequisites
 
-You will need kuberentes nodes that can provide up to 32GB and 4CPU per replica. The following example
+You will need kubernetes nodes that can provide up to 32GB and 4CPU per replica. The following example
 deploys 2 replicas.
 
 ### Install the CRDs and deploy operator in your cluster


### PR DESCRIPTION
### Title
`quick_start.md Typo fix`

### Description
This pull request fixes a minor typo in the `quick_start.md` file:
- Corrected "kuberentes" to "kubernetes" for improved clarity and accuracy.
