### PR TITLE
feat: allow external service account for pods

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -107,6 +107,10 @@ type FullNodeSpec struct {
 	// complexity of the CosmosFullNodeController.
 	// +optional
 	SelfHeal *SelfHealSpec `json:"selfHeal"`
+
+	// If set, the pod will use the specified service account. If not set, pods will create and use an isolated service account.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName"`
 }
 
 type FullNodeType string

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -5891,6 +5891,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountName:
+                description: If set, the pod will use the specified service account.
+                  If not set, pods will create and use an isolated service account.
+                type: string
               strategy:
                 description: How to scale pods when performing an update.
                 properties:

--- a/internal/fullnode/rbac_builder.go
+++ b/internal/fullnode/rbac_builder.go
@@ -10,6 +10,9 @@ import (
 )
 
 func serviceAccountName(crd *cosmosv1.CosmosFullNode) string {
+	if crd.Spec.ServiceAccountName != "" {
+		return crd.Spec.ServiceAccountName
+	}
 	return crd.Name + "-vc-sa"
 }
 
@@ -25,6 +28,10 @@ func roleBindingName(crd *cosmosv1.CosmosFullNode) string {
 //
 // Creates a single service account for the version check.
 func BuildServiceAccounts(crd *cosmosv1.CosmosFullNode) []diff.Resource[*corev1.ServiceAccount] {
+	if crd.Spec.ServiceAccountName != "" {
+		return nil
+	}
+
 	diffSa := make([]diff.Resource[*corev1.ServiceAccount], 1)
 	sa := corev1.ServiceAccount{
 		TypeMeta: v1.TypeMeta{

--- a/internal/fullnode/role_binding_control.go
+++ b/internal/fullnode/role_binding_control.go
@@ -25,6 +25,10 @@ func NewRoleBindingControl(client Client) RoleBindingControl {
 
 // Reconcile creates or updates role bindings.
 func (sc RoleBindingControl) Reconcile(ctx context.Context, log kube.Logger, crd *cosmosv1.CosmosFullNode) kube.ReconcileError {
+	if crd.Spec.ServiceAccountName != "" {
+		return nil
+	}
+
 	var crs rbacv1.RoleBindingList
 	if err := sc.client.List(ctx, &crs,
 		client.InNamespace(crd.Namespace),

--- a/internal/fullnode/role_control.go
+++ b/internal/fullnode/role_control.go
@@ -25,6 +25,10 @@ func NewRoleControl(client Client) RoleControl {
 
 // Reconcile creates or updates roles.
 func (sc RoleControl) Reconcile(ctx context.Context, log kube.Logger, crd *cosmosv1.CosmosFullNode) kube.ReconcileError {
+	if crd.Spec.ServiceAccountName != "" {
+		return nil
+	}
+
 	var crs rbacv1.RoleList
 	if err := sc.client.List(ctx, &crs,
 		client.InNamespace(crd.Namespace),

--- a/internal/fullnode/service_account_control.go
+++ b/internal/fullnode/service_account_control.go
@@ -25,6 +25,10 @@ func NewServiceAccountControl(client Client) ServiceAccountControl {
 
 // Reconcile creates or updates service accounts.
 func (sc ServiceAccountControl) Reconcile(ctx context.Context, log kube.Logger, crd *cosmosv1.CosmosFullNode) kube.ReconcileError {
+	if crd.Spec.ServiceAccountName != "" {
+		return nil
+	}
+
 	var sas corev1.ServiceAccountList
 	if err := sc.client.List(ctx, &sas,
 		client.InNamespace(crd.Namespace),


### PR DESCRIPTION
Enable providing service account externally for version check container to publish height to cosmosfullnode status