### PR TITLE
fix: unique name label on additionalVersionedPods

### DIFF
--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -557,6 +557,9 @@ func buildAdditionalPod(
 	// Create a unique name for the additional pod
 	name := fmt.Sprintf("%s-%d", podSpec.Name, ordinal)
 
+	labels := defaultLabels(crd)
+	labels[kube.NameLabel] = appName(crd) + "-" + podSpec.Name
+
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -565,7 +568,7 @@ func buildAdditionalPod(
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   crd.Namespace,
 			Name:        name,
-			Labels:      defaultLabels(crd),
+			Labels:      labels,
 			Annotations: make(map[string]string),
 		},
 		Spec: podSpec.PodSpec,


### PR DESCRIPTION
Many of our internal selectors depend on the `app.kubernetes.io/name` label pointing to the cosmos nodes, so remove from the additionalVersionedPods.