### PR TITLE
feat: allow prefer scheduling additional pods on same node as main pods

### DIFF
--- a/api/v1/cosmosfullnode_types.go
+++ b/api/v1/cosmosfullnode_types.go
@@ -337,6 +337,11 @@ type AdditionalPodSpec struct {
 	Metadata Metadata `json:"metadata"`
 
 	corev1.PodSpec `json:",inline"`
+
+	// Whether to prefer the same node as the main pod for the additional pod.
+	// This is useful for pods that are not part of the main pod's deployment, but should still be co-located.
+	// +optional
+	PreferSameNode bool `json:"preferSameNode,omitempty"`
 }
 
 type FullNodeProbeStrategy string

--- a/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
+++ b/config/crd/bases/cosmos.strange.love_cosmosfullnodes.yaml
@@ -3379,6 +3379,11 @@ spec:
                                                 One of Never, PreemptLowerPriority.
                                                 Defaults to PreemptLowerPriority if unset.
                                             type: string
+                                        preferSameNode:
+                                            description: |-
+                                                Whether to prefer the same node as the main pod for the additional pod.
+                                                This is useful for pods that are not part of the main pod's deployment, but should still be co-located.
+                                            type: boolean
                                         priority:
                                             description: |-
                                                 The priority value. Various system components use this field to find the


### PR DESCRIPTION
`preferSameNode` on the `additionalVersionedPods` spec will prefer scheduling the pods on the same node as the main pod if set to true.