### PR TITLE
Use musl toolchain from SL s3 bucket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ ARG TARGETARCH
 ARG BUILDARCH
 
 RUN if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then \
-        wget -c https://musl.cc/aarch64-linux-musl-cross.tgz -O - | tar -xzvv --strip-components 1 -C /usr; \
+        wget -c https://storage.googleapis.com/strangelove-public/musl/aarch64-linux-musl-cross.tgz -O - | tar -xzvv --strip-components 1 -C /usr; \
     elif [ "${TARGETARCH}" = "amd64" ] && [ "${BUILDARCH}" != "amd64" ]; then \
-        wget -c https://musl.cc/x86_64-linux-musl-cross.tgz -O - | tar -xzvv --strip-components 1 -C /usr; \
+        wget -c https://storage.googleapis.com/strangelove-public/musl/x86_64-linux-musl-cross.tgz -O - | tar -xzvv --strip-components 1 -C /usr; \
     fi
 
 RUN set -eux;\


### PR DESCRIPTION
https://musl.cc/ No longer accepts downloads from github actions

![image](https://github.com/user-attachments/assets/603f29c4-686e-4b6b-9046-c77dd1839583)

Downloaded toolchain and uploaded to our s3 bucket as a temporary fix.