### PR TITLE
fix: use dynamic ports from CometConfig in service builder

### DIFF
--- a/internal/fullnode/service_builder.go
+++ b/internal/fullnode/service_builder.go
@@ -58,7 +58,7 @@ func BuildServices(crd *cosmosv1.CosmosFullNode) []diff.Resource[*corev1.Service
 			{
 				Name:       "p2p",
 				Protocol:   corev1.ProtocolTCP,
-				Port:       p2pPort,
+				Port:       crd.Spec.ChainSpec.Comet.P2PPort(),
 				TargetPort: intstr.FromString("p2p"),
 			},
 		}
@@ -148,7 +148,7 @@ func rpcService(crd *cosmosv1.CosmosFullNode) *corev1.Service {
 		{
 			Name:       "rpc",
 			Protocol:   corev1.ProtocolTCP,
-			Port:       rpcPort,
+			Port:       crd.Spec.ChainSpec.Comet.RPCPort(),
 			TargetPort: intstr.FromString("rpc"),
 		},
 		{

--- a/internal/fullnode/service_builder_test.go
+++ b/internal/fullnode/service_builder_test.go
@@ -51,7 +51,7 @@ func TestBuildServices(t *testing.T) {
 					{
 						Name:       "p2p",
 						Protocol:   corev1.ProtocolTCP,
-						Port:       26656,
+						Port:       crd.Spec.ChainSpec.Comet.P2PPort(),
 						TargetPort: intstr.FromString("p2p"),
 					},
 				},
@@ -92,7 +92,7 @@ func TestBuildServices(t *testing.T) {
 					{
 						Name:       "p2p",
 						Protocol:   corev1.ProtocolTCP,
-						Port:       26656,
+						Port:       crd.Spec.ChainSpec.Comet.P2PPort(),
 						TargetPort: intstr.FromString("p2p"),
 					},
 				},
@@ -192,7 +192,7 @@ func TestBuildServices(t *testing.T) {
 					{
 						Name:       "p2p",
 						Protocol:   corev1.ProtocolTCP,
-						Port:       26656,
+						Port:       crd.Spec.ChainSpec.Comet.P2PPort(),
 						TargetPort: intstr.FromString("p2p"),
 					},
 				},
@@ -310,7 +310,7 @@ func TestBuildServices(t *testing.T) {
 			{
 				Name:       "rpc",
 				Protocol:   corev1.ProtocolTCP,
-				Port:       26657,
+				Port:       crd.Spec.ChainSpec.Comet.RPCPort(),
 				TargetPort: intstr.FromString("rpc"),
 			},
 			{


### PR DESCRIPTION
## Summary
  - Fixes port mismatches between container ports and service ports when users configure custom `rpcListenAddress` or `p2pListenAddress`

  ## Changes
  - **service_builder.go:61**: Changed `Port: p2pPort,` to `Port: crd.Spec.ChainSpec.Comet.P2PPort(),`
  - **service_builder.go:151**: Changed `Port: rpcPort,` to `Port: crd.Spec.ChainSpec.Comet.RPCPort(),`
  - **service_builder_test.go**: Updated tests to use dynamic ports instead of hardcoded values