### PR TITLE
feat: make sidecar container image configurable to fix forked repository deployments

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: image name need to be lowercase
+        run: |
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >>${GITHUB_ENV}
+        env:
+          IMAGE_NAME: '${{ env.IMAGE_NAME }}'  
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
@@ -55,7 +61,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: VERSION=${{ steps.meta.outputs.version }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Run Trivy vulnerability scanner
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ COPY controllers/ controllers/
 COPY internal/ internal/
 
 ARG VERSION
+ARG IMG
 
 RUN set -eux;\
     if [ "${TARGETARCH}" = "arm64" ] && [ "${BUILDARCH}" != "arm64" ]; then\
@@ -73,7 +74,7 @@ RUN set -eux;\
             LDFLAGS='-linkmode external -extldflags "-static"' \
             CGO_CFLAGS="-I/rocksdb/include" \
             CGO_LDFLAGS="-L/rocksdb -L/usr/lib -L/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy -llz4 -lzstd";\
-    go build -tags 'rocksdb pebbledb' -ldflags "-X github.com/strangelove-ventures/cosmos-operator/internal/version.version=$VERSION $LDFLAGS" -a -o manager .
+    go build -tags 'rocksdb pebbledb' -ldflags "-X github.com/strangelove-ventures/cosmos-operator/internal/version.version=$VERSION -X github.com/strangelove-ventures/cosmos-operator/internal/version.image=$IMG $LDFLAGS" -a -o manager .
 
 # Build final image from scratch
 FROM scratch

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -95,7 +95,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 					Name: "healthcheck",
 					// Available images: https://github.com/orgs/strangelove-ventures/packages?repo_name=cosmos-operator
 					// IMPORTANT: Must use v0.6.2 or later.
-					Image:   "ghcr.io/strangelove-ventures/cosmos-operator:" + version.DockerTag(),
+					Image:   version.Image() + ":" + version.DockerTag(),
 					Command: []string{"/manager", "healthcheck", "--rpc-host", fmt.Sprintf("http://localhost:%d", crd.Spec.ChainSpec.Comet.RPCPort())},
 					Ports:   []corev1.ContainerPort{{ContainerPort: healthCheckPort, Protocol: corev1.ProtocolTCP}},
 					Resources: corev1.ResourceRequirements{
@@ -115,7 +115,7 @@ func NewPodBuilder(crd *cosmosv1.CosmosFullNode) PodBuilder {
 		// version check sidecar, runs on inverval in case the instance is halting for upgrade.
 		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
 			Name:    "version-check-interval",
-			Image:   "ghcr.io/strangelove-ventures/cosmos-operator:" + version.DockerTag(),
+			Image:   version.Image() + ":" + version.DockerTag(),
 			Command: versionCheckCmd,
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -461,7 +461,7 @@ fi
 	// After the status is patched, the pod will be restarted with the correct image.
 	required = append(required, corev1.Container{
 		Name:    "version-check",
-		Image:   "ghcr.io/strangelove-ventures/cosmos-operator:" + version.DockerTag(),
+		Image:   version.Image() + ":" + version.DockerTag(),
 		Command: versionCheckCmd,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,6 +5,7 @@ package version
 // Used for docker image.
 // See Dockerfile, Makefile, and .github/workflows/release.yaml.
 var version = ""
+var image = ""
 
 // DockerTag returns the version of the build or "latest" if unknown.
 func DockerTag() string {
@@ -20,4 +21,12 @@ func AppVersion() string {
 		return "(devel)"
 	}
 	return version
+}
+
+// Image returns the image name of the build.
+func Image() string {
+	if image == "" {
+		return "ghcr.io/strangelove-ventures/cosmos-operator"
+	}
+	return image
 }


### PR DESCRIPTION
## Problem
When forked repositories create custom images with tags like `v0.25.1-test`, the sidecar containers (healthcheck, version-check-interval, and version-check) still try to fetch the hardcoded image `ghcr.io/strangelove-ventures/cosmos-operator:v0.25.1-test`, which doesn't exist in the upstream registry. This causes deployment failures for forked repositories.

## Solution
Refactored image retrieval in pod builder to use a new `version.Image()` method instead of hardcoded image references, enabling forked repositories to override the container image via build-time ldflags.

## Changes Made
- **Added new `version.Image()` method** in `internal/version/version.go` that returns configurable image name
- **Updated pod builder** (`internal/fullnode/pod_builder.go`) to use `version.Image()` instead of hardcoded `ghcr.io/strangelove-ventures/cosmos-operator`
- **Enhanced Docker build process** to accept `IMG` build argument and pass it via ldflags
- **Fixed GitHub Actions workflow** to properly handle lowercase image names and pass image name as build argument

## Benefits
- **Fixes deployment issues** for forked repositories using custom image registries
- **Maintains backward compatibility** - defaults to original image if not overridden
- **Enables proper testing** for downstream consumers with custom images
- **Follows existing build-time configuration pattern** similar to version handling

## Usage for Forked Repositories
Forked repositories can now set their custom image during build:
```bash
go build -ldflags "-X github.com/strangelove-ventures/cosmos-operator/internal/version.image=ghcr.io/my-fork/cosmos-operator"