### PR TITLE
feat: add automatic version labeling to pods based on container images

### DIFF
--- a/internal/fullnode/build_pods.go
+++ b/internal/fullnode/build_pods.go
@@ -3,6 +3,7 @@ package fullnode
 import (
 	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
 	"github.com/strangelove-ventures/cosmos-operator/internal/diff"
+	"github.com/strangelove-ventures/cosmos-operator/internal/kube"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -56,6 +57,10 @@ func BuildPods(crd *cosmosv1.CosmosFullNode, cksums ConfigChecksums) ([]diff.Res
 		}
 	}
 	return pods, nil
+}
+
+func updatePodVersionLabel(pod *corev1.Pod, img string) {
+	pod.Labels[kube.VersionLabel] = kube.ParseImageVersion(img)
 }
 
 func setVersionedImages(pod *corev1.Pod, v *cosmosv1.ChainVersion) {

--- a/internal/fullnode/build_pods_test.go
+++ b/internal/fullnode/build_pods_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/samber/lo"
 	cosmosv1 "github.com/strangelove-ventures/cosmos-operator/api/v1"
 	"github.com/strangelove-ventures/cosmos-operator/internal/diff"
+	"github.com/strangelove-ventures/cosmos-operator/internal/kube"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,8 +103,10 @@ func TestBuildPods(t *testing.T) {
 			image := pod.Object().Spec.Containers[0].Image
 			if pod.Object().Name == overridePod {
 				require.Equal(t, overrideImage, image)
+				require.Equal(t, kube.ParseImageVersion(overrideImage), pod.Object().Labels[kube.VersionLabel])
 			} else {
 				require.Equal(t, image, image)
+				require.Equal(t, kube.ParseImageVersion(image), pod.Object().Labels[kube.VersionLabel])
 			}
 		}
 	})
@@ -216,8 +219,10 @@ func TestBuildPods(t *testing.T) {
 			image := pod.Object().Spec.Containers[0].Image
 			if pod.Object().Name == overridePod {
 				require.Equal(t, overrideImage, image)
+				require.Equal(t, kube.ParseImageVersion(overrideImage), pod.Object().Labels[kube.VersionLabel])
 			} else {
 				require.Equal(t, image, image)
+				require.Equal(t, kube.ParseImageVersion(image), pod.Object().Labels[kube.VersionLabel])
 			}
 		}
 	})

--- a/internal/fullnode/pod_builder.go
+++ b/internal/fullnode/pod_builder.go
@@ -203,6 +203,7 @@ func (b PodBuilder) Build() (*corev1.Pod, error) {
 		}
 		if vrs != nil {
 			setVersionedImages(pod, vrs)
+			updatePodVersionLabel(pod, vrs.Image)
 		}
 	}
 
@@ -212,6 +213,7 @@ func (b PodBuilder) Build() (*corev1.Pod, error) {
 		}
 		if o.Image != "" {
 			setChainContainerImage(pod, o.Image)
+			updatePodVersionLabel(pod, o.Image)
 		}
 		if o.NodeSelector != nil {
 			pod.Spec.NodeSelector = o.NodeSelector

--- a/internal/fullnode/pod_builder_test.go
+++ b/internal/fullnode/pod_builder_test.go
@@ -714,6 +714,8 @@ gaiad start --home /home/operator/cosmos`
 		require.Equal(t, "chain-init", pod0.Spec.InitContainers[1].Name)
 		require.Equal(t, "image:v1.0.0", pod0.Spec.InitContainers[1].Image)
 
+		require.Equal(t, "v1.0.0", pod0.Labels[kube.VersionLabel])
+
 		pod1, err := builder.WithOrdinal(1).Build()
 		require.NoError(t, err)
 
@@ -724,6 +726,8 @@ gaiad start --home /home/operator/cosmos`
 
 		require.Equal(t, "chain-init", pod1.Spec.InitContainers[1].Name)
 		require.Equal(t, "image:v2.0.0", pod1.Spec.InitContainers[1].Image)
+
+		require.Equal(t, "v2.0.0", pod1.Labels[kube.VersionLabel])
 
 		pod2, err := builder.WithOrdinal(2).Build()
 		require.NoError(t, err)
@@ -742,6 +746,8 @@ gaiad start --home /home/operator/cosmos`
 		require.Equal(t, "new-init", pod2.Spec.InitContainers[2].Name)
 		require.Equal(t, "new-init:v3.0.0", pod2.Spec.InitContainers[2].Image)
 
+		require.Equal(t, "v3.0.0", pod2.Labels[kube.VersionLabel])
+
 		crd.Status.Height["osmosis-2"] = 400
 		pod2, err = builder.WithOrdinal(2).Build()
 		require.NoError(t, err)
@@ -759,6 +765,8 @@ gaiad start --home /home/operator/cosmos`
 
 		require.Equal(t, "new-init", pod2.Spec.InitContainers[2].Name)
 		require.Equal(t, "new-init:latest", pod2.Spec.InitContainers[2].Image)
+
+		require.Equal(t, "v4.0.0", pod2.Labels[kube.VersionLabel])
 	})
 }
 


### PR DESCRIPTION
## Summary
Adds automatic version labeling to pods by extracting version information from container images and setting it as a Kubernetes label using `kube.VersionLabel`.

## Problem
Previously, pods created by the cosmos-operator lacked version information in their labels, making it difficult for operators and monitoring tools to identify which version of the blockchain software was running in each pod.

## Solution
- **Added `updatePodVersionLabel()` function** that extracts version from container image using `kube.ParseImageVersion()`
- **Integrated version labeling** at two key points:
  1. When setting versioned images from chain versions
  2. When overriding images via pod overrides
- **Comprehensive test coverage** to ensure version labels are correctly set

## Changes Made
- **New function**: `updatePodVersionLabel()` in `internal/fullnode/build_pods.go`
- **Integration points**: Called in `pod_builder.go` when images are set or overridden
- **Enhanced tests**: Added assertions in both `build_pods_test.go` and `pod_builder_test.go`
