### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/internal/kube/rollout.go
+++ b/internal/kube/rollout.go
@@ -39,9 +39,6 @@ func ComputeRollout(maxUnavail *intstr.IntOrString, desired, ready int) int {
 		return 0
 	}
 
-	target := unavail - (desired - ready)
-	if target > desired {
-		target = desired
-	}
+	target := min(unavail-(desired-ready), desired)
 	return target
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.